### PR TITLE
Update RPM spec to specify 4.2 as version

### DIFF
--- a/openshift-kuryr-kubernetes.spec
+++ b/openshift-kuryr-kubernetes.spec
@@ -13,7 +13,7 @@ with OpenStack networking.
 %global commit 0000000
 
 Name:      openshift-%project
-Version:   4.1.0
+Version:   4.2.0
 Release:   1%{?dist}
 Summary:   OpenStack networking integration with OpenShift and Kubernetes
 License:   ASL 2.0

--- a/tools/build-rpm.sh
+++ b/tools/build-rpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-version=4.1.0
+version=4.2.0
 source_path=_output/SOURCES
 
 mkdir -p ${source_path}


### PR DESCRIPTION
Seems like in OKD builds we don't have the RPM version overwritten when
rpmbuild is exectued, so we need to keep it updated manually. This
commit updates master to set RPM version to 4.2.