### PR TITLE
Remove RDO repos workaround

### DIFF
--- a/openshift-kuryr-cni-ci.Dockerfile
+++ b/openshift-kuryr-cni-ci.Dockerfile
@@ -13,15 +13,6 @@ ARG OSLO_LOCK_PATH=/var/kuryr-lock
 #               yum-config-manager is unable to enable them. Using sed for now.
 RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/*
 
-# FIXME(dulek): Until I'll figure out how to get OpenStack repos here, we need this hack.
-RUN yum install --setopt=tsflags=nodocs -y \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-    && printf '[openstack-stein]\n\
-name=OpenStack Stein Repository\n\
-baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-stein/\n\
-gpgcheck=0\n\
-enabled=1\n' >> /etc/yum.repos.d/rdo-stein.repo
-
 COPY --from=builder /go/bin/kuryr-cni /kuryr-cni
 
 RUN yum update -y \

--- a/openshift-kuryr-controller-ci.Dockerfile
+++ b/openshift-kuryr-controller-ci.Dockerfile
@@ -6,15 +6,6 @@ ENV container=oci
 #               yum-config-manager is unable to enable them. Using sed for now.
 RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/*
 
-# FIXME(dulek): Until I'll figure out how to get OpenStack repos here, we need this hack.
-RUN yum install --setopt=tsflags=nodocs -y \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-    && printf '[openstack-stein]\n\
-name=OpenStack Stein Repository\n\
-baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-stein/\n\
-gpgcheck=0\n\
-enabled=1\n' >> /etc/yum.repos.d/rdo-stein.repo
-
 RUN yum update -y \
  && yum install -y openshift-kuryr-controller \
  && yum clean all \


### PR DESCRIPTION
This removes the workaround that injects the RDO repositories as
OpenStack mirrors were missing from OpenShift buildsystem. It's now
resolved.