### PR TITLE
Bump the RPM version in the spec

### DIFF
--- a/openshift-kuryr-kubernetes.spec
+++ b/openshift-kuryr-kubernetes.spec
@@ -13,7 +13,7 @@ with OpenStack networking.
 %global commit 0000000
 
 Name:      openshift-%project
-Version:   4.2.0
+Version:   4.2.1
 Release:   1%{?dist}
 Summary:   OpenStack networking integration with OpenShift and Kubernetes
 License:   ASL 2.0

--- a/openshift-kuryr-tester.Dockerfile
+++ b/openshift-kuryr-tester.Dockerfile
@@ -6,7 +6,8 @@ RUN yum update -y \
  && yum install -y python-devel python-pbr python-pip \
  && yum clean all \
  && rm -rf /var/cache/yum \
- && pip install tox
+ && pip install "more-itertools<6.0.0" tox
+# more-itertools 6.0.0 drops support for Python 2.7, so we need to ensure we have older version.
 
 LABEL \
         io.k8s.description="This is a component of OpenShift Container Platform and provides a testing container for Kuryr service." \

--- a/tools/build-rpm.sh
+++ b/tools/build-rpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-version=4.2.0
+version=4.2.1
 source_path=_output/SOURCES
 
 mkdir -p ${source_path}


### PR DESCRIPTION
This commit bumps the version in the RPM spec to force the built RPM to
be preferred over the ones that are already in the repository.