### PR TITLE
3.11 buildsystem fixes

### DIFF
--- a/openshift-kuryr-cni-ci.Dockerfile
+++ b/openshift-kuryr-cni-ci.Dockerfile
@@ -11,7 +11,7 @@ ARG OSLO_LOCK_PATH=/var/kuryr-lock
 
 # FIXME(dulek): For some reason the local repos are disabled by default and
 #               yum-config-manager is unable to enable them. Using sed for now.
-RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/*
+RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/built.repo
 
 # FIXME(dulek): Until I'll figure out how to get OpenStack repos here, we need this hack.
 RUN yum install --setopt=tsflags=nodocs -y \

--- a/openshift-kuryr-cni-ci.Dockerfile
+++ b/openshift-kuryr-cni-ci.Dockerfile
@@ -40,5 +40,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-cni" \
         io.k8s.display-name="kuryr-cni" \
-        version="4.2.0" \
+        version="3.11.0" \
         com.redhat.component="kuryr-cni-container"

--- a/openshift-kuryr-cni-ci.Dockerfile
+++ b/openshift-kuryr-cni-ci.Dockerfile
@@ -13,6 +13,15 @@ ARG OSLO_LOCK_PATH=/var/kuryr-lock
 #               yum-config-manager is unable to enable them. Using sed for now.
 RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/*
 
+# FIXME(dulek): Until I'll figure out how to get OpenStack repos here, we need this hack.
+RUN yum install --setopt=tsflags=nodocs -y \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    && printf '[openstack-stein]\n\
+name=OpenStack Stein Repository\n\
+baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-stein/\n\
+gpgcheck=0\n\
+enabled=1\n' >> /etc/yum.repos.d/rdo-stein.repo
+
 COPY --from=builder /go/bin/kuryr-cni /kuryr-cni
 
 RUN yum update -y \

--- a/openshift-kuryr-cni.Dockerfile
+++ b/openshift-kuryr-cni.Dockerfile
@@ -27,5 +27,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-cni" \
         io.k8s.display-name="kuryr-cni" \
-        version="4.2.0" \
+        version="3.11.0" \
         com.redhat.component="kuryr-cni-container"

--- a/openshift-kuryr-controller-ci.Dockerfile
+++ b/openshift-kuryr-controller-ci.Dockerfile
@@ -6,6 +6,15 @@ ENV container=oci
 #               yum-config-manager is unable to enable them. Using sed for now.
 RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/*
 
+# FIXME(dulek): Until I'll figure out how to get OpenStack repos here, we need this hack.
+RUN yum install --setopt=tsflags=nodocs -y \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    && printf '[openstack-stein]\n\
+name=OpenStack Stein Repository\n\
+baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-stein/\n\
+gpgcheck=0\n\
+enabled=1\n' >> /etc/yum.repos.d/rdo-stein.repo
+
 RUN yum update -y \
  && yum install -y openshift-kuryr-controller \
  && yum clean all \

--- a/openshift-kuryr-controller-ci.Dockerfile
+++ b/openshift-kuryr-controller-ci.Dockerfile
@@ -29,5 +29,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-controller" \
         io.k8s.display-name="kuryr-controller" \
-        version="4.2.0" \
+        version="3.11.0" \
         com.redhat.component="kuryr-controller-container"

--- a/openshift-kuryr-controller-ci.Dockerfile
+++ b/openshift-kuryr-controller-ci.Dockerfile
@@ -4,7 +4,7 @@ ENV container=oci
 
 # FIXME(dulek): For some reason the local repos are disabled by default and
 #               yum-config-manager is unable to enable them. Using sed for now.
-RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/*
+RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/built.repo
 
 # FIXME(dulek): Until I'll figure out how to get OpenStack repos here, we need this hack.
 RUN yum install --setopt=tsflags=nodocs -y \

--- a/openshift-kuryr-controller.Dockerfile
+++ b/openshift-kuryr-controller.Dockerfile
@@ -16,5 +16,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-controller" \
         io.k8s.display-name="kuryr-controller" \
-        version="4.2.0" \
+        version="3.11.0" \
         com.redhat.component="kuryr-controller-container"

--- a/openshift-kuryr-kubernetes.spec
+++ b/openshift-kuryr-kubernetes.spec
@@ -13,7 +13,7 @@ with OpenStack networking.
 %global commit 0000000
 
 Name:      openshift-%project
-Version:   4.2.0
+Version:   3.11.1
 Release:   1%{?dist}
 Summary:   OpenStack networking integration with OpenShift and Kubernetes
 License:   ASL 2.0

--- a/openshift-kuryr-tester.Dockerfile
+++ b/openshift-kuryr-tester.Dockerfile
@@ -6,7 +6,8 @@ RUN yum update -y \
  && yum install -y python-devel python-pbr python-pip \
  && yum clean all \
  && rm -rf /var/cache/yum \
- && pip install tox
+ && pip install "more-itertools<6.0.0" tox
+# more-itertools 6.0.0 drops support for Python 2.7, so we need to ensure we have older version.
 
 LABEL \
         io.k8s.description="This is a component of OpenShift Container Platform and provides a testing container for Kuryr service." \

--- a/openshift-kuryr-tester.Dockerfile
+++ b/openshift-kuryr-tester.Dockerfile
@@ -14,5 +14,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-tester" \
         io.k8s.display-name="kuryr-tester" \
-        version="4.0.0" \
+        version="3.11.0" \
         com.redhat.component="kuryr-tester-container"

--- a/tools/build-rpm.sh
+++ b/tools/build-rpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-version=4.2.0
+version=3.11.1
 source_path=_output/SOURCES
 
 mkdir -p ${source_path}


### PR DESCRIPTION
This PR updates necessary versions and adds some hacks required to build Kuryr containers against 3.11 buildsystem.