### PR TITLE
Install python-setuptools, not python2-setuptools

### DIFF
--- a/openshift-kuryr-kubernetes.spec
+++ b/openshift-kuryr-kubernetes.spec
@@ -39,7 +39,7 @@ Summary:        Kuryr Kubernetes libraries
 
 BuildRequires:  git
 BuildRequires:  python2-devel
-BuildRequires:  python2-setuptools
+BuildRequires:  python-setuptools
 BuildRequires:  python2-pbr
 BuildRequires:  systemd-units
 


### PR DESCRIPTION
Seems like for 3.11 we only have python-setuptools RPM package and
python2-setuptools is missing. This commit switches to use the latter.