### PR TITLE
Bug 1756981: Ensure no LBaaS SG update is triggered for SVCs without selectors and ports

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -962,7 +962,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
 
         svc_namespace = service['metadata']['namespace']
         svc_name = service['metadata']['name']
-        svc_ports = service['spec']['ports']
+        svc_ports = service['spec'].get('ports', [])
 
         lbaas_name = "%s/%s" % (svc_namespace, svc_name)
 

--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -445,6 +445,8 @@ def service_matches_affected_pods(service, pod_selectors):
             and False otherwise.
     """
     svc_selector = service['spec'].get('selector')
+    if not svc_selector:
+        return False
     for selector in pod_selectors:
         if match_selector(selector, svc_selector):
             return True

--- a/kuryr_kubernetes/controller/handlers/pod_label.py
+++ b/kuryr_kubernetes/controller/handlers/pod_label.py
@@ -103,9 +103,8 @@ class PodLabelHandler(k8s_base.ResourceEventHandler):
 
     def _update_services(self, services, crd_pod_selectors, project_id):
         for service in services.get('items'):
-            if (service['metadata']['name'] == 'kubernetes' or not
-                    driver_utils.service_matches_affected_pods(
-                        service, crd_pod_selectors)):
+            if not driver_utils.service_matches_affected_pods(
+                    service, crd_pod_selectors):
                 continue
             sgs = self._drv_svc_sg.get_security_groups(service,
                                                        project_id)

--- a/kuryr_kubernetes/controller/handlers/policy.py
+++ b/kuryr_kubernetes/controller/handlers/policy.py
@@ -86,7 +86,7 @@ class NetworkPolicyHandler(k8s_base.ResourceEventHandler):
             for service in services.get('items'):
                 # TODO(ltomasbo): Skip other services that are not affected
                 # by the policy
-                if (service['metadata']['name'] == 'kubernetes' or not
+                if (not service['spec'].get('selector') or not
                         self._is_service_affected(service, pods_to_update)):
                     continue
                 sgs = self._drv_svc_sg.get_security_groups(service,
@@ -122,7 +122,7 @@ class NetworkPolicyHandler(k8s_base.ResourceEventHandler):
                 services = driver_utils.get_services(
                     policy['metadata']['namespace'])
                 for svc in services.get('items'):
-                    if (svc['metadata']['name'] == 'kubernetes' or not
+                    if (not svc['spec'].get('selector') or not
                             self._is_service_affected(svc, pods_to_update)):
                         continue
                     sgs = self._drv_svc_sg.get_security_groups(svc,

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -251,9 +251,8 @@ class VIFHandler(k8s_base.ResourceEventHandler):
 
     def _update_services(self, services, crd_pod_selectors, project_id):
         for service in services.get('items'):
-            if (service['metadata']['name'] == 'kubernetes' or not
-                    driver_utils.service_matches_affected_pods(
-                        service, crd_pod_selectors)):
+            if not driver_utils.service_matches_affected_pods(
+                    service, crd_pod_selectors):
                 continue
             sgs = self._drv_svc_sg.get_security_groups(service,
                                                        project_id)


### PR DESCRIPTION
When a Network Policy is enforced we shouldn't try to update the
SG of a LBaaS that would map to a SVC without selector, as this
kind of SVC is not wired by Kuryr. Also, we shouldn't try to update
the LBaaS SG when no ports are defined in the SVC spec.
