### PR TITLE
Bug 1758528: Ensure ports from pool do not reference deleted SGs/NPs

### DIFF
--- a/kuryr_kubernetes/controller/drivers/base.py
+++ b/kuryr_kubernetes/controller/drivers/base.py
@@ -741,6 +741,21 @@ class VIFPoolDriver(PodVIFDriver):
         """
         raise NotImplementedError()
 
+    @abc.abstractmethod
+    def remove_sg_from_pools(self, sg_id, net_id):
+        """Remove the SG from the ports associated to the pools.
+
+        This method ensure that ports on net_id that belongs to pools and have
+        the referenced SG are updated to clean up their SGs and put back on
+        the default pool for that network.
+
+        :param sg_id: Security Group ID that needs to be removed from pool
+                      ports
+        :param net_id: Network ID associated to the pools to clean up, and
+                       where the ports must belong to.
+        """
+        raise NotImplementedError()
+
 
 @six.add_metaclass(abc.ABCMeta)
 class ServicePubIpDriver(DriverBase):

--- a/kuryr_kubernetes/controller/handlers/policy.py
+++ b/kuryr_kubernetes/controller/handlers/policy.py
@@ -20,6 +20,7 @@ from kuryr_kubernetes import clients
 from kuryr_kubernetes import constants as k_const
 from kuryr_kubernetes.controller.drivers import base as drivers
 from kuryr_kubernetes.controller.drivers import utils as driver_utils
+from kuryr_kubernetes import exceptions
 from kuryr_kubernetes.handlers import k8s_base
 from kuryr_kubernetes import utils
 
@@ -116,6 +117,10 @@ class NetworkPolicyHandler(k8s_base.ResourceEventHandler):
                             oslo_cfg.OptGroup('neutron_defaults'))
                 self._drv_vif_pool.update_vif_sgs(pod, pod_sgs)
 
+            # ensure ports at the pool don't have the NP sg associated
+            net_id = self._get_policy_net_id(policy)
+            self._drv_vif_pool.remove_sg_from_pools(crd_sg, net_id)
+
             self._drv_policy.release_network_policy(netpolicy_crd)
 
             if oslo_cfg.CONF.octavia_defaults.enforce_sg_rules:
@@ -149,3 +154,16 @@ class NetworkPolicyHandler(k8s_base.ResourceEventHandler):
         svc_pods = driver_utils.get_pods({'selector': svc_selector},
                                          svc_namespace).get('items')
         return any(pod in svc_pods for pod in affected_pods)
+
+    def _get_policy_net_id(self, policy):
+        policy_ns = policy['metadata']['namespace']
+        kuryrnet_name = 'ns-' + str(policy_ns)
+
+        kubernetes = clients.get_kubernetes_client()
+        try:
+            net_crd = kubernetes.get('{}/{}'.format(
+                k_const.K8S_API_CRD_KURYRNETS, kuryrnet_name))
+        except exceptions.K8sClientException:
+            LOG.exception("Kubernetes Client Exception.")
+            raise
+        return net_crd['spec']['netId']

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_policy.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_policy.py
@@ -78,6 +78,8 @@ class TestPolicyHandler(test_base.TestCase):
         self._update_vif_sgs.return_value = None
         self._update_lbaas_sg = self._handler._drv_lbaas.update_lbaas_sg
         self._update_lbaas_sg.return_value = None
+        self._remove_sg = self._handler._drv_vif_pool.remove_sg_from_pools
+        self._remove_sg.return_value = None
 
     def _get_knp_obj(self):
         knp_obj = {
@@ -243,3 +245,4 @@ class TestPolicyHandler(test_base.TestCase):
                                                           self._project_id)
         self._update_vif_sgs.assert_called_once_with(match_pod, sg1)
         self._update_lbaas_sg.assert_not_called()
+        self._remove_sg.assert_called_once()


### PR DESCRIPTION
When a NP is deleted its associated SG should be deleted too.
However, when using pools, ports may have that SG assigned, not
allowing the SG deletion and consequently stoping the kuryrnetpolicy
associated object deletion -- which may cause kuryr-controller crashes
too