### PR TITLE
Bug 1759984: Fix race conditions between handling ResourceNotReady and deletions

### DIFF
--- a/kuryr_kubernetes/controller/drivers/namespace_subnet.py
+++ b/kuryr_kubernetes/controller/drivers/namespace_subnet.py
@@ -56,6 +56,9 @@ class NamespacePodSubnetDriver(default_subnet.DefaultPodSubnetDriver):
         try:
             ns = kubernetes.get('%s/namespaces/%s' % (constants.K8S_API_BASE,
                                                       namespace))
+        except exceptions.K8sResourceNotFound:
+            LOG.warning("Namespace %s not found", namespace)
+            raise
         except exceptions.K8sClientException:
             LOG.exception("Kubernetes Client Exception.")
             raise exceptions.ResourceNotReady(namespace)

--- a/kuryr_kubernetes/controller/drivers/namespace_subnet.py
+++ b/kuryr_kubernetes/controller/drivers/namespace_subnet.py
@@ -64,13 +64,16 @@ class NamespacePodSubnetDriver(default_subnet.DefaultPodSubnetDriver):
             annotations = ns['metadata']['annotations']
             net_crd_name = annotations[constants.K8S_ANNOTATION_NET_CRD]
         except KeyError:
-            LOG.exception("Namespace missing CRD annotations for selecting "
-                          "the corresponding subnet.")
+            LOG.warning("Namespace missing CRD annotations for selecting the "
+                        "corresponding subnet.")
             raise exceptions.ResourceNotReady(namespace)
 
         try:
             net_crd = kubernetes.get('%s/kuryrnets/%s' % (
                 constants.K8S_API_CRD, net_crd_name))
+        except exceptions.K8sResourceNotFound:
+            LOG.warning("Kuryrnet resource not yet created, retrying...")
+            raise exceptions.ResourceNotReady(net_crd_name)
         except exceptions.K8sClientException:
             LOG.exception("Kubernetes Client Exception.")
             raise

--- a/kuryr_kubernetes/controller/drivers/network_policy_security_groups.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy_security_groups.py
@@ -532,12 +532,9 @@ class NetworkPolicySecurityGroupsDriver(base.PodSecurityGroupsDriver):
         return crd_selectors
 
     def create_namespace_sg_rules(self, namespace):
-        kubernetes = clients.get_kubernetes_client()
         ns_name = namespace['metadata']['name']
         LOG.debug("Creating sg rule for namespace: %s", ns_name)
         crd_selectors = []
-        namespace = kubernetes.get(
-            '{}/namespaces/{}'.format(constants.K8S_API_BASE, ns_name))
         knp_crds = driver_utils.get_kuryrnetpolicy_crds()
         for crd in knp_crds.get('items'):
             crd_selector = crd['spec'].get('podSelector')

--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -306,7 +306,11 @@ class LoadBalancerHandler(k8s_base.ResourceEventHandler):
     def _add_new_members(self, endpoints, lbaas_state, lbaas_spec):
         changed = False
 
-        self._sync_lbaas_sgs(endpoints, lbaas_state, lbaas_spec)
+        try:
+            self._sync_lbaas_sgs(endpoints, lbaas_state, lbaas_spec)
+        except k_exc.K8sResourceNotFound:
+            LOG.debug("The svc has been deleted while processing the endpoints"
+                      " update. No need to add new members.")
 
         lsnr_by_id = {l.id: l for l in lbaas_state.listeners}
         pool_by_lsnr_port = {(lsnr_by_id[p.listener_id].protocol,

--- a/kuryr_kubernetes/controller/handlers/namespace.py
+++ b/kuryr_kubernetes/controller/handlers/namespace.py
@@ -120,8 +120,9 @@ class NamespaceHandler(k8s_base.ResourceEventHandler):
             net_crd = self._add_kuryrnet_crd(ns_name, net_crd_spec)
             self._set_net_crd(namespace, net_crd)
             self._drv_sg.create_namespace_sg_rules(namespace)
-        except exceptions.K8sClientException:
-            LOG.exception("Kubernetes client exception. Rolling back "
+        except (exceptions.K8sClientException,
+                exceptions.K8sResourceNotFound):
+            LOG.exception("Kuryrnet CRD creation failed. Rolling back "
                           "resources created for the namespace.")
             self._drv_subnets.rollback_network_resources(net_crd_spec, ns_name)
             if net_crd_sg.get('sgId'):

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -94,7 +94,7 @@ class VIFHandler(k8s_base.ResourceEventHandler):
         if not state:
             try:
                 subnets = self._drv_subnets.get_subnets(pod, project_id)
-            except n_exc.NotFound:
+            except (n_exc.NotFound, k_exc.K8sResourceNotFound):
                 LOG.warning("Subnet does not exists. If namespace driver is "
                             "used, probably the namespace for the pod is "
                             "already deleted. So this pod does not need to "

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -40,7 +40,7 @@ VALID_MULTI_POD_POOLS_OPTS = {'noop': ['neutron-vif',
                               'neutron': ['neutron-vif'],
                               'nested': ['nested-vlan'],
                               }
-DEFAULT_TIMEOUT = 180
+DEFAULT_TIMEOUT = 500
 DEFAULT_INTERVAL = 3
 
 subnet_caching_opts = [


### PR DESCRIPTION
There are different races conditions between retry actions (activation vif, getting vif for a pod, ...) and deletion actions. It may happen that some retry action gets postponed until the resource has already been deleted, leading to kuryr-controller errors.