### PR TITLE
Bug 1761505: Avoid controller crash upon unexpected neutron error handling ports

### DIFF
--- a/kuryr_kubernetes/controller/drivers/nested_vlan_vif.py
+++ b/kuryr_kubernetes/controller/drivers/nested_vlan_vif.py
@@ -98,10 +98,12 @@ class NestedVlanPodVIFDriver(nested_vif.NestedPodVIFDriver):
                 LOG.error("vlan ids already in use on trunk")
                 for port in ports:
                     neutron.delete_port(port['id'])
-                raise
+                return []
         except n_exc.NeutronClientException:
             LOG.exception("Error happened during subport addition to trunk")
-            raise
+            for port in ports:
+                neutron.delete_port(port['id'])
+            return []
 
         vifs = []
         for index, port in enumerate(ports):

--- a/kuryr_kubernetes/controller/drivers/vif_pool.py
+++ b/kuryr_kubernetes/controller/drivers/vif_pool.py
@@ -244,6 +244,8 @@ class BaseVIFPool(base.VIFPoolDriver):
                 self._available_ports_pools.setdefault(
                     pool_key, {}).setdefault(
                         security_groups, []).append(vif.id)
+            if not vifs:
+                self._last_update[pool_key] = {security_groups: last_update}
 
     def release_vif(self, pod, vif, project_id, security_groups):
         host_addr = self._get_host_addr(pod)

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_nested_vlan_vif.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_nested_vlan_vif.py
@@ -222,9 +222,8 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
         neutron.create_port.return_value = {'ports': [port, port]}
         neutron.trunk_add_subports.side_effect = n_exc.Conflict
 
-        self.assertRaises(n_exc.Conflict, cls.request_vifs,
-                          m_driver, pod, project_id, subnets,
-                          security_groups, num_ports)
+        self.assertEqual([], cls.request_vifs(m_driver, pod, project_id,
+                         subnets, security_groups, num_ports))
 
         m_driver._get_parent_port.assert_called_once_with(neutron, pod)
         m_driver._get_trunk_id.assert_called_once_with(parent_port)
@@ -267,9 +266,8 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
         neutron.create_port.return_value = {'ports': [port, port]}
         neutron.trunk_add_subports.side_effect = n_exc.NeutronClientException
 
-        self.assertRaises(n_exc.NeutronClientException, cls.request_vifs,
-                          m_driver, pod, project_id, subnets,
-                          security_groups, num_ports)
+        self.assertEqual([], cls.request_vifs(m_driver, pod, project_id,
+                         subnets, security_groups, num_ports))
 
         m_driver._get_parent_port.assert_called_once_with(neutron, pod)
         m_driver._get_trunk_id.assert_called_once_with(parent_port)
@@ -279,7 +277,7 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
         neutron.create_port.assert_called_once_with(bulk_rq)
         neutron.trunk_add_subports.assert_called_once_with(
             trunk_id, {'sub_ports': subports_info})
-        neutron.delete_port.assert_not_called()
+        neutron.delete_port.assert_called_with(port['id'])
 
     def test_release_vif(self):
         cls = nested_vlan_vif.NestedVlanPodVIFDriver


### PR DESCRIPTION
This PS ensures that kuryr-controller does not crash if neutron
cannot be reached to check the port status, or if neutron replies
with unexpected error when trying to add ports to the trunks
