### PR TITLE
Switch to RHEL8 and OSP16

### DIFF
--- a/openshift-kuryr-cni-ci-rhel8.Dockerfile
+++ b/openshift-kuryr-cni-ci-rhel8.Dockerfile
@@ -1,0 +1,34 @@
+FROM openshift/origin-release:golang-1.11 AS builder
+
+WORKDIR /go/src/github.com/openshift/kuryr-kubernetes
+COPY . .
+RUN go build -o /go/bin/kuryr-cni ./kuryr_cni
+
+FROM ubi8
+
+ENV container=oci
+ARG OSLO_LOCK_PATH=/var/kuryr-lock
+
+# FIXME(dulek): For some reason the local repos are disabled by default and
+#               yum-config-manager is unable to enable them. Using sed for now.
+RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/*
+
+COPY --from=builder /go/bin/kuryr-cni /kuryr-cni
+
+RUN dnf install -y openshift-kuryr-cni iproute openvswitch \
+ && dnf clean all \
+ && rm -rf /var/cache/yum
+
+ARG CNI_DAEMON=True
+ENV CNI_DAEMON ${CNI_DAEMON}
+ENV OSLO_LOCK_PATH ${OSLO_LOCK_PATH}
+
+ENTRYPOINT /usr/libexec/kuryr/cni_ds_init
+
+LABEL \
+        io.k8s.description="This is a component of OpenShift Container Platform and provides a kuryr-cni service." \
+        maintainer="Michal Dulko <mdulko@redhat.com>" \
+        name="openshift/kuryr-cni" \
+        io.k8s.display-name="kuryr-cni" \
+        version="4.3.0" \
+        com.redhat.component="kuryr-cni-container"

--- a/openshift-kuryr-cni-rhel8.Dockerfile
+++ b/openshift-kuryr-cni-rhel8.Dockerfile
@@ -1,0 +1,30 @@
+FROM openshift/origin-release:golang-1.11 AS builder
+
+WORKDIR /go/src/github.com/openshift/kuryr-kubernetes
+COPY . .
+RUN go build -o /go/bin/kuryr-cni ./kuryr_cni
+
+FROM ubi8
+
+ENV container=oci
+ARG OSLO_LOCK_PATH=/var/kuryr-lock
+
+COPY --from=builder /go/bin/kuryr-cni /kuryr-cni
+
+RUN dnf install -y openshift-kuryr-cni iproute openvswitch \
+ && dnf clean all \
+ && rm -rf /var/cache/yum
+
+ARG CNI_DAEMON=True
+ENV CNI_DAEMON ${CNI_DAEMON}
+ENV OSLO_LOCK_PATH ${OSLO_LOCK_PATH}
+
+ENTRYPOINT /usr/libexec/kuryr/cni_ds_init
+
+LABEL \
+        io.k8s.description="This is a component of OpenShift Container Platform and provides a kuryr-cni service." \
+        maintainer="Michal Dulko <mdulko@redhat.com>" \
+        name="openshift/kuryr-cni" \
+        io.k8s.display-name="kuryr-cni" \
+        version="4.3.0" \
+        com.redhat.component="kuryr-cni-container"

--- a/openshift-kuryr-controller-ci-rhel8.Dockerfile
+++ b/openshift-kuryr-controller-ci-rhel8.Dockerfile
@@ -1,0 +1,23 @@
+FROM ubi8
+
+ENV container=oci
+
+# FIXME(dulek): For some reason the local repos are disabled by default and
+#               yum-config-manager is unable to enable them. Using sed for now.
+RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/*
+
+RUN dnf install -y openshift-kuryr-controller \
+ && dnf clean all \
+ && rm -rf /var/cache/yum
+
+USER kuryr
+CMD ["--config-dir", "/etc/kuryr"]
+ENTRYPOINT [ "/usr/bin/kuryr-k8s-controller" ]
+
+LABEL \
+        io.k8s.description="This is a component of OpenShift Container Platform and provides a kuryr-controller service." \
+        maintainer="Michal Dulko <mdulko@redhat.com>" \
+        name="openshift/kuryr-controller" \
+        io.k8s.display-name="kuryr-controller" \
+        version="4.3.0" \
+        com.redhat.component="kuryr-controller-container"

--- a/openshift-kuryr-controller-rhel8.Dockerfile
+++ b/openshift-kuryr-controller-rhel8.Dockerfile
@@ -1,0 +1,19 @@
+FROM ubi8
+
+ENV container=oci
+
+RUN dnf install -y openshift-kuryr-controller \
+ && dnf clean all \
+ && rm -rf /var/cache/yum
+
+USER kuryr
+CMD ["--config-dir", "/etc/kuryr"]
+ENTRYPOINT [ "/usr/bin/kuryr-k8s-controller" ]
+
+LABEL \
+        io.k8s.description="This is a component of OpenShift Container Platform and provides a kuryr-controller service." \
+        maintainer="Michal Dulko <mdulko@redhat.com>" \
+        name="openshift/kuryr-controller" \
+        io.k8s.display-name="kuryr-controller" \
+        version="4.3.0" \
+        com.redhat.component="kuryr-controller-container"

--- a/openshift-kuryr-kubernetes-rhel8.spec
+++ b/openshift-kuryr-kubernetes-rhel8.spec
@@ -1,0 +1,194 @@
+%{!?upstream_version: %global upstream_version %{version}%{?milestone}}
+%global project kuryr
+%global service kuryr-kubernetes
+%global module kuryr_kubernetes
+
+%global common_desc \
+Kuryr Kubernetes provides a Controller that watches the Kubernetes API for \
+Object changes and manages Neutron resources to provide the Kubernetes Cluster \
+with OpenStack networking.
+
+# %commit is intended to be set by tito builders at packaging time.
+# The value in this spec file will not be kept up to date.
+%global commit 0000000
+
+Name:      openshift-%project
+Version:   4.3.1
+Release:   1%{?dist}
+Summary:   OpenStack networking integration with OpenShift and Kubernetes
+License:   ASL 2.0
+URL:       http://docs.openstack.org/developer/kuryr-kubernetes/
+
+Source0:   %{service}.tar.gz
+Source1:   kuryr.logrotate
+Source2:   kuryr-controller.service
+Source3:   openshift-kuryr.tmpfs
+Source4:   kuryr-cni.service
+
+BuildArch: noarch
+
+Requires(pre): shadow-utils
+%{?systemd_requires}
+
+%description
+Kuryr-Kubernetes brings OpenStack networking to OpenShift and Kubernetes clusters
+
+%package -n python3-%{service}
+Summary:        Kuryr Kubernetes libraries
+%{?python_provide:%python_provide python3-%{service}}
+
+BuildRequires:  git
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pbr
+BuildRequires:  systemd-units
+
+Requires:       python3-%{project}-lib >= 0.5.0
+Requires:       python3-pyroute2 >= 0.4.21
+Requires:       python3-requests >= 2.14.2
+Requires:       python3-eventlet >= 0.18.2
+Requires:       python3-oslo-cache >= 1.26.0
+Requires:       python3-oslo-config >= 2:5.2.0
+Requires:       python3-oslo-log >= 3.36.0
+Requires:       python3-oslo-reports >= 1.18.0
+Requires:       python3-oslo-serialization >= 2.18.0
+Requires:       python3-oslo-service >= 1.24.0
+Requires:       python3-oslo-utils >= 3.33.0
+Requires:       python3-os-vif >= 1.7.0
+Requires:       python3-six >= 1.10.0
+Requires:       python3-stevedore >= 1.20.0
+Requires:       python3-cotyledon >= 1.3.0
+Requires:       python3-flask >= 0.10.0
+Requires:       python3-retrying >= 1.2.3
+Requires:       python3-grpcio >= 1.12.0
+Requires:       python3-protobuf >= 3.6.0
+
+%description -n python3-%{service}
+%{common_desc}
+
+This package contains the Kuryr Kubernetes Python library.
+
+%package common
+Summary:        Kuryr Kubernetes common files
+Group:          Applications/System
+Requires:   python3-%{service} = %{version}-%{release}
+
+%description common
+This package contains Kuryr files common to all services.
+
+%package controller
+Summary: Kuryr Kubernetes Controller
+Requires: openshift-%{project}-common = %{version}-%{release}
+
+%description controller
+%{common_desc}
+
+This package contains the Kuryr Kubernetes Controller that watches the
+Kubernetes API and adds metadata to its Objects about the OpenStack resources
+it obtains.
+
+%package cni
+Summary: CNI plugin
+Requires: openshift-%{project}-common = %{version}-%{release}
+%{?systemd_requires}
+
+%description cni
+%{common_desc}
+
+This package contains the Kuryr Kubernetes Container Network Interface driver
+that Kubelet calls to.
+
+%prep
+%autosetup -n %{service}-%{upstream_version} -S git
+
+find %{module} -name \*.py -exec sed -i '/\/usr\/bin\/env python/{d;q}' {} +
+
+# Let's handle dependencies ourseleves
+rm -f requirements.txt
+rm -f test-requirements.txt
+rm -f doc/requirements.txt
+
+# Kill egg-info in order to generate new SOURCES.txt
+rm -rf kuryr_kubernetes.egg-info
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+# Create config files directories
+install -d -m 755 %{buildroot}%{_sysconfdir}/%{project}
+install -d -m 755 %{buildroot}%{_localstatedir}/log/%{project}
+
+# Install logrotate
+install -p -D -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/logrotate.d/openshift-%{service}
+
+# Install systemd units
+install -p -D -m 644 %{SOURCE2} %{buildroot}%{_unitdir}/kuryr-controller.service
+install -p -D -m 644 %{SOURCE4} %{buildroot}%{_unitdir}/kuryr-cni.service
+
+# Kuryr run directories
+install -p -D -m 644 %{SOURCE3} %{buildroot}%{_tmpfilesdir}/openshift-kuryr.conf
+install -d %{buildroot}%{_localstatedir}/run/kuryr
+
+# Kuryr cni_ds_init
+install -d -m 755 %{buildroot}%{_libexecdir}/%{project}
+install -p -D -m 755 cni_ds_init %{buildroot}%{_libexecdir}/%{project}/
+install -p -D -m 755 etc/cni/net.d/10-kuryr.conf %{buildroot}%{_sysconfdir}/%{project}-cni/10-kuryr.conf
+
+%pre -n python3-%{service}
+getent group %{project} >/dev/null || groupadd -r %{project}
+getent passwd %{project} >/dev/null || \
+    useradd -r -g %{project} -d %{_sharedstatedir}/%{project} -s /sbin/nologin \
+    -c "OpenStack Kuryr Daemons" %{project}
+exit 0
+
+%post controller
+%systemd_post kuryr-controller.service
+
+%preun controller
+%systemd_preun kuryr-controller.service
+
+%postun controller
+%systemd_postun_with_restart kuryr-controller.service
+
+%post cni
+%systemd_post kuryr-cni.service
+
+%preun cni
+%systemd_preun kuryr-cni.service
+
+%postun cni
+%systemd_postun_with_restart kuryr-cni.service
+
+%files controller
+%license LICENSE
+%{_bindir}/kuryr-k8s-controller
+%{_bindir}/kuryr-k8s-status
+%{_bindir}/kuryr-dns-webhook
+%{_unitdir}/kuryr-controller.service
+
+%files -n python3-%{service}
+%license LICENSE
+%{python3_sitelib}/%{module}
+%{python3_sitelib}/%{module}-*.egg-info
+%exclude %{python3_sitelib}/%{module}/tests
+
+%files common
+%license LICENSE
+%doc README.rst
+%dir %attr(0755, %{project}, %{project}) %{_sysconfdir}/%{project}
+%config(noreplace) %{_sysconfdir}/logrotate.d/*
+%dir %attr(0755, %{project}, %{project}) %{_localstatedir}/log/%{project}
+%{_tmpfilesdir}/openshift-kuryr.conf
+%dir %attr(0755, %{project}, %{project}) %{_localstatedir}/run/kuryr
+
+%files cni
+%license LICENSE
+%{_bindir}/kuryr-cni
+%{_bindir}/kuryr-daemon
+%{_unitdir}/kuryr-cni.service
+%dir %attr(0755, root, root) %{_libexecdir}/%{project}
+%{_libexecdir}/%{project}/cni_ds_init
+%config(noreplace) %attr(0640, root, %{project}) %{_sysconfdir}/%{project}-cni/10-kuryr.conf

--- a/openshift-kuryr-tester-rhel8.Dockerfile
+++ b/openshift-kuryr-tester-rhel8.Dockerfile
@@ -1,0 +1,16 @@
+FROM ubi8
+
+ENV container=oci
+
+RUN yum install -y python3-devel python3-pbr python3-pip \
+ && yum clean all \
+ && rm -rf /var/cache/yum \
+ && pip3 install tox
+
+LABEL \
+        io.k8s.description="This is a component of OpenShift Container Platform and provides a testing container for Kuryr service." \
+        maintainer="Michal Dulko <mdulko@redhat.com>" \
+        name="openshift/kuryr-tester" \
+        io.k8s.display-name="kuryr-tester" \
+        version="4.0.0" \
+        com.redhat.component="kuryr-tester-container"

--- a/tools/build-rpm-rhel8.sh
+++ b/tools/build-rpm-rhel8.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -x
+
+version=4.3.1
+source_path=_output/SOURCES
+
+mkdir -p ${source_path}
+
+# NOTE(dulek): rpmbuild requires that inside the tar there will be a
+#              ${service}-${version} directory, hence this --transform option.
+#              Also note that for some reason it doesn't work without excluding
+#              .git directory. Excluding .tox is convenient for local builds.
+tar -czvf ${source_path}/kuryr-kubernetes.tar.gz --exclude=.git --exclude=.tox --transform "flags=r;s|\.|kuryr-kubernetes-${version}|" .
+cp kuryr.logrotate ${source_path}
+cp kuryr-controller.service ${source_path}
+cp openshift-kuryr.tmpfs ${source_path}
+cp kuryr-cni.service ${source_path}
+
+# NOTE(dulek): We use this to get python3-pbr package in here.
+curl http://base-openstack-4-3.ocp.svc > /etc/yum.repos.d/base-openstack-4-3.repo
+
+yum install -y python3-pbr python3-devel
+
+rpmbuild -ba -D "_topdir `pwd`/_output" openshift-kuryr-kubernetes-rhel8.spec
+createrepo _output/RPMS/noarch


### PR DESCRIPTION
In order to have the latest possible dependencies, this commit switches
Kuryr images to use RHEL8 and OSP16.