### PR TITLE
Revert "Protect from keystoneauth 3.10.0 bug"

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -65,14 +65,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
         self._octavia_tags = False
         # Check if Octavia API supports tagging.
         lbaas = clients.get_loadbalancer_client()
-        try:
-            v = lbaas.get_api_major_version()
-        except IndexError:
-            # There's a bug in keystoneauth1 3.10.0 that raises this if Octavia
-            # is old, let's just assume we don't know in that case. For details
-            # see commit c40eb2951d5cf24589ea357a11aa252978636020 there.
-            v = None
-
+        v = lbaas.get_api_major_version()
         if v >= _OCTAVIA_TAGGING_VERSION:
             LOG.info('Octavia supports resource tags.')
             self._octavia_tags = True


### PR DESCRIPTION
This reverts commit 819d0c0ff4f5ab51fef223efa0ee76e8f66167a1. We now
build with keystoneauth 3.17.1, so this should be safe to revert. This
resolves #37.

Change-Id: I3fd5dc90cfc3333ef294f6dc89833faa7bdf550c