### PR TITLE
Revert "Copy config options from kuryr-lib directly here"

### DIFF
--- a/kuryr_kubernetes/clients.py
+++ b/kuryr_kubernetes/clients.py
@@ -16,9 +16,7 @@
 from functools import partial
 import os
 
-from keystoneauth1 import loading as ks_loading
 from kuryr.lib import utils
-from neutronclient.v2_0 import client
 from openstack import connection
 from openstack import exceptions as os_exc
 from openstack.network.v2 import port as os_port
@@ -32,7 +30,6 @@ _NEUTRON_CLIENT = 'neutron-client'
 _KUBERNETES_CLIENT = 'kubernetes-client'
 _OPENSTACKSDK = 'openstacksdk'
 _POD_RESOURCES_CLIENT = 'pod-resources-client'
-CONF = config.CONF
 
 
 def get_network_client():
@@ -66,18 +63,7 @@ def setup_clients():
 
 
 def setup_neutron_client():
-    # Taken from kuryr.lib
-    conf_group = config.neutron_group.name
-    auth_plugin = ks_loading.load_auth_from_conf_options(CONF, conf_group)
-    session = ks_loading.load_session_from_conf_options(CONF, conf_group,
-                                                        auth=auth_plugin)
-    endpoint_type = getattr(getattr(CONF, conf_group), 'endpoint_type')
-    region_name = getattr(getattr(CONF, conf_group), 'region_name')
-
-    _clients[_NEUTRON_CLIENT] = client.Client(session=session,
-                                              auth=auth_plugin,
-                                              endpoint_type=endpoint_type,
-                                              region_name=region_name)
+    _clients[_NEUTRON_CLIENT] = utils.get_neutron_client()
 
 
 def setup_kubernetes_client():

--- a/kuryr_kubernetes/config.py
+++ b/kuryr_kubernetes/config.py
@@ -12,7 +12,6 @@
 import os
 import sys
 
-from keystoneauth1 import loading as ks_loading
 from kuryr.lib._i18n import _
 from kuryr.lib import config as lib_config
 from oslo_config import cfg
@@ -308,40 +307,6 @@ sriov_opts = [
                 default=DEFAULT_PHYSNET_SUBNET_MAPPINGS),
 ]
 
-# Those are taken from kuryr-lib.
-neutron_group = cfg.OptGroup(
-    'neutron',
-    title='Neutron Options',
-    help=_('Configuration options for OpenStack Neutron'))
-
-neutron_opts = [
-    cfg.StrOpt('enable_dhcp',
-               default='True',
-               help=_('Enable or Disable dhcp for neutron subnets.')),
-    cfg.StrOpt('default_subnetpool_v4',
-               default='kuryr',
-               help=_('Name of default subnetpool version 4')),
-    cfg.StrOpt('default_subnetpool_v6',
-               default='kuryr6',
-               help=_('Name of default subnetpool version 6')),
-    cfg.BoolOpt('vif_plugging_is_fatal',
-                default=False,
-                help=_("Whether a plugging operation is failed if the port "
-                       "to plug does not become active")),
-    cfg.IntOpt('vif_plugging_timeout',
-               default=0,
-               help=_("Seconds to wait for port to become active")),
-    cfg.StrOpt('region_name',
-               default=None,
-               help=_('Region name of the neturon endpoint to use.')),
-    cfg.StrOpt('endpoint_type',
-               default='public',
-               choices=['public', 'admin', 'internal'],
-               help=_('Type of the neutron endpoint to use. This endpoint '
-                      'will be looked up in the keystone catalog and should '
-                      'be one of public, internal or admin.')),
-]
-
 
 CONF = cfg.CONF
 CONF.register_opts(kuryr_k8s_opts)
@@ -356,12 +321,7 @@ CONF.register_opts(sriov_opts, group='sriov')
 
 CONF.register_opts(lib_config.core_opts)
 CONF.register_opts(lib_config.binding_opts, 'binding')
-
-# Taken from kuryr-lib
-CONF.register_group(neutron_group)
-CONF.register_opts(neutron_opts, group=neutron_group)
-ks_loading.register_session_conf_options(CONF, neutron_group.name)
-ks_loading.register_auth_conf_options(CONF, neutron_group.name)
+lib_config.register_neutron_opts(CONF)
 
 logging.register_options(CONF)
 

--- a/kuryr_kubernetes/tests/unit/test_clients.py
+++ b/kuryr_kubernetes/tests/unit/test_clients.py
@@ -24,7 +24,7 @@ class TestK8sClient(test_base.TestCase):
     @mock.patch('openstack.connection.Connection')
     @mock.patch('kuryr_kubernetes.config.CONF')
     @mock.patch('kuryr_kubernetes.k8s_client.K8sClient')
-    @mock.patch('neutronclient.v2_0.client.Client')
+    @mock.patch('kuryr.lib.utils.get_neutron_client')
     def test_setup_clients(self, m_neutron, m_k8s, m_cfg, m_openstack):
         k8s_api_root = 'http://127.0.0.1:1234'
 


### PR DESCRIPTION
With OSP16 version of kuryr-lib we should be able to revert copying its options inside kuryr-kubernetes code.