### PR TITLE
Bug 1754046: Ensure kuryr webhook is running before other operators' pods

### DIFF
--- a/kuryr_kubernetes/cmd/webhook_server.py
+++ b/kuryr_kubernetes/cmd/webhook_server.py
@@ -16,18 +16,53 @@
 import argparse
 import base64
 import copy
+import os
 
 from flask import Flask
 from flask import jsonify
 from flask import request
 import jsonpatch
 
+from kuryr_kubernetes import constants
+from kuryr_kubernetes import exceptions
+from kuryr_kubernetes import k8s_client
 
 app = Flask(__name__)
+first_request = True
 
 
 @app.route('/', methods=['POST'])
 def webhook():
+    global first_request
+    if first_request:
+        first_request = False
+        host = os.environ['KUBERNETES_SERVICE_HOST']
+        port = os.environ['KUBERNETES_SERVICE_PORT']
+        api_root = "https://%s:%s" % (host, port)
+        k8s = k8s_client.K8sClient(api_root)
+        # list of namespaces with operators to delete
+        for ns in app.config['ns_to_clear']:
+            try:
+                pods = k8s.get('{}/namespaces/{}/pods'.format(
+                    constants.K8S_API_BASE, ns))
+            except (exceptions.K8sClientException,
+                    exceptions.K8sResourceNotFound):
+                # unexpected exception, ensure it gets retried
+                first_request = True
+                continue
+            for pod in pods.get('items'):
+                options = pod['spec'].get('dnsConfig', {}).get('options', [])
+                if not [o for o in options if o['name'] == 'use-vc']:
+                    try:
+                        k8s.delete('{}/namespaces/{}/pods/{}'.format(
+                            constants.K8S_API_BASE, ns,
+                            pod['metadata']['name']))
+                    except (exceptions.K8sClientException,
+                            exceptions.K8sResourceNotFound):
+                        # unexpected exception, ensure it gets retried
+                        first_request = True
+                        continue
+
     request_info = request.json
 
     obj = request_info['request']['object']
@@ -78,8 +113,13 @@ def main():
         '--tls-private-key-file', default='key.pem',
         help='File containing the default x509 private key matching '
              '--tls-cert-file.')
+    parser.add_argument(
+        '--ns', action='append',
+        help='List of namespaces with pods to delete to ensure right creation '
+             'order.')
     args = parser.parse_args()
 
+    app.config['ns_to_clear'] = args.ns
     app.run(host=args.bind_address, port=args.port,
             ssl_context=(args.tls_cert_file, args.tls_private_key_file))
 

--- a/kuryr_kubernetes/config.py
+++ b/kuryr_kubernetes/config.py
@@ -87,13 +87,14 @@ k8s_opts = [
                       "connect to HTTPS K8S_API")),
     cfg.StrOpt('ssl_ca_crt_file',
                help=_("Absolute path to ca cert file to "
-                      "connect to HTTPS K8S_API")),
+                      "connect to HTTPS K8S_API"),
+               default='/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'),
     cfg.BoolOpt('ssl_verify_server_crt',
                 help=_("HTTPS K8S_API server identity verification"),
                 default=False),
     cfg.StrOpt('token_file',
                help=_("The token to talk to the k8s API"),
-               default=''),
+               default='/var/run/secrets/kubernetes.io/serviceaccount/token'),
     cfg.StrOpt('pod_project_driver',
                help=_("The driver to determine OpenStack "
                       "project for pod ports"),

--- a/kuryr_kubernetes/tests/unit/cmd/test_status.py
+++ b/kuryr_kubernetes/tests/unit/cmd/test_status.py
@@ -24,7 +24,9 @@ from kuryr_kubernetes.tests import base as test_base
 
 
 class TestStatusCmd(test_base.TestCase):
-    def setUp(self):
+    @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
+    @mock.patch('kuryr_kubernetes.clients.setup_kubernetes_client')
+    def setUp(self, m_client_setup, m_client_get):
         super(TestStatusCmd, self).setUp()
         self.cmd = status.UpgradeCommands()
 

--- a/kuryr_kubernetes/tests/unit/test_k8s_client.py
+++ b/kuryr_kubernetes/tests/unit/test_k8s_client.py
@@ -26,9 +26,15 @@ from kuryr_kubernetes.tests import base as test_base
 
 
 class TestK8sClient(test_base.TestCase):
-    def setUp(self):
+    @mock.patch('kuryr_kubernetes.config.CONF')
+    def setUp(self, m_cfg):
         super(TestK8sClient, self).setUp()
         self.base_url = 'http://127.0.0.1:12345'
+        m_cfg.kubernetes.ssl_client_crt_file = None
+        m_cfg.kubernetes.ssl_client_key_file = None
+        m_cfg.kubernetes.ssl_ca_crt_file = None
+        m_cfg.kubernetes.token_file = None
+        m_cfg.kubernetes.ssl_verify_server_crt = False
         self.client = k8s_client.K8sClient(self.base_url)
         default_cert = (None, None)
         default_token = None


### PR DESCRIPTION
This PR ensure that Kuryr-admission-controller is up and ready (including its associated service) before other operators so that the proper dns configuration is enforced