### PR TITLE
Bug 1779163: Nested CNI: Look for leftover ifaces to remove

### DIFF
--- a/kuryr_kubernetes/cni/binding/base.py
+++ b/kuryr_kubernetes/cni/binding/base.py
@@ -34,6 +34,22 @@ LOG = logging.getLogger(__name__)
 class BaseBindingDriver(object):
     """Interface to attach ports to pods."""
 
+    def _remove_ifaces(self, ipdb, ifnames, netns='host'):
+        """Check if any of `ifnames` exists and remove it.
+
+        :param ipdb: ipdb of the network namespace to check
+        :param ifnames: iterable of interface names to remove
+        :param netns: network namespace name (used for logging)
+        """
+        for ifname in ifnames:
+            if ifname in ipdb.interfaces:
+                LOG.warning('Found hanging interface %(ifname)s inside '
+                            '%(netns)s netns. Most likely it is a leftover '
+                            'from a kuryr-daemon restart. Trying to delete '
+                            'it.', {'ifname': ifname, 'netns': netns})
+                with ipdb.interfaces[ifname] as iface:
+                    iface.remove()
+
     @abc.abstractmethod
     def connect(self, vif, ifname, netns, container_id):
         raise NotImplementedError()

--- a/kuryr_kubernetes/tests/unit/cni/test_binding.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_binding.py
@@ -180,7 +180,7 @@ class TestNestedVlanDriver(TestDriverMixin, test_base.TestCase):
         self._test_connect()
 
         self.assertEqual(1, self.h_ipdb_exit.call_count)
-        self.assertEqual(2, self.c_ipdb_exit.call_count)
+        self.assertEqual(3, self.c_ipdb_exit.call_count)
 
         self.assertEqual(self.ifname, self.m_h_iface.ifname)
         self.assertEqual(1, self.m_h_iface.mtu)
@@ -202,7 +202,7 @@ class TestNestedMacvlanDriver(TestDriverMixin, test_base.TestCase):
         self._test_connect()
 
         self.assertEqual(1, self.h_ipdb_exit.call_count)
-        self.assertEqual(2, self.c_ipdb_exit.call_count)
+        self.assertEqual(3, self.c_ipdb_exit.call_count)
 
         self.assertEqual(self.ifname, self.m_h_iface.ifname)
         self.assertEqual(1, self.m_h_iface.mtu)


### PR DESCRIPTION
If kuryr-daemon was restarted during nested interface binding, after the
pod interface got created, but before returning to kubelet, such a
request will get retried by kubelet. As the interface with either
vif.vif_name or CNI request's ifname will already exist in the pod
namespace, the call will fail with NetlinkError: (17, 'File exists').

To prevent that this commit adds a check for such interfaces. If they
exist - they got removed before the real binding starts.

Change-Id: Iaa4d472fb4681e4d9af93561bdccdcb62ce500a0