### PR TITLE
Bug 1786299: Ensure LB sg update is retried when NP is enforced

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -971,7 +971,8 @@ class LBaaSv2Driver(base.LBaaSDriver):
 
         lbaas = utils.get_lbaas_state(endpoint)
         if not lbaas:
-            return
+            LOG.debug('Endpoint not yet annotated with lbaas state.')
+            raise k_exc.ResourceNotReady(svc_name)
 
         lbaas_obj = lbaas.loadbalancer
         lbaas_obj.security_groups = sgs


### PR DESCRIPTION
In case an endpoint is not yet annotated with the lbaas
state, when a Network Policy enforcement is triggered,
the update of the lbaas SG is ignored, causing a security breach.
This commit fixes the issue by retrying the update of the sg.

Change-Id: I4ebb8d5da52ff2cee8970b061e31b3f391cacc1b