### PR TITLE
Bug 1786140: Ensure LB member is removed upon pod removal

### DIFF
--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_lbaas.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_lbaas.py
@@ -654,7 +654,7 @@ class TestLoadBalancerHandler(test_base.TestCase):
         self.assertEqual(subnet_id, observed_subnet_id)
 
     def _generate_lbaas_state(self, vip, targets, project_id, subnet_id):
-        name = 'DUMMY_NAME'
+        name = 'namespace/DUMMY_NAME'
         drv = FakeLBaaSDriver()
         lb = drv.ensure_loadbalancer(
             name, project_id, subnet_id, vip, None, 'ClusterIP')


### PR DESCRIPTION
When pods that run on host network and are pointed by a svc
are removed, the removal of the load balancer member is
ignored, as right now the name of the pod is not taken into
account on the decision of which members to delete, and the
current attributes checked are pod ip and port, which remains
the same. This commit fixes the issue by ensuring the
pod name is also checked.

Change-Id: I44f7f76da692ac3002c91a1420969584b4d31cbd