### PR TITLE
Bug 1792239: Avoid KeyError when deleting NPs

### DIFF
--- a/kuryr_kubernetes/controller/drivers/vif_pool.py
+++ b/kuryr_kubernetes/controller/drivers/vif_pool.py
@@ -310,7 +310,13 @@ class BaseVIFPool(base.VIFPoolDriver):
                 if sg_id not in sg_key:
                     continue
                 # remove the pool associated to that SG
-                del self._available_ports_pools[pool_key][sg_key]
+                try:
+                    del self._available_ports_pools[pool_key][sg_key]
+                except KeyError:
+                    LOG.debug("SG already removed from the pool. Ports "
+                              "already re-used, no need to change their "
+                              "associated SGs.")
+                    continue
                 for port_id in ports:
                     # remove all SGs from the port to be reused
                     neutron.update_port(


### PR DESCRIPTION
It seems that when an namespace deletion fails for some reason and
it is retried, if there are other NPs created, some of the unused
ports can be reused and moved from one sg_key to another, therefore
raising the KeyError on the retry.

This patch ensure that if the sg_key was already deleted, the retry
skips it instead of failing

Change-Id: Ifcebf7660861738128606342dc6dab00186878b5