### PR TITLE
Bug 1788650: Ensure lb SG is not updated on member creation

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -599,7 +599,8 @@ class LBaaSv2Driver(base.LBaaSDriver):
         network_policy = (
             'policy' in CONF.kubernetes.enabled_handlers and
             CONF.kubernetes.service_security_groups_driver == 'policy')
-        if network_policy and listener_port:
+        if (network_policy and CONF.octavia_defaults.enforce_sg_rules and
+                listener_port):
             protocol = pool.protocol
             sg_rule_name = pool.name
             listener_id = pool.listener_id


### PR DESCRIPTION
When enforce_sg_rules is not set the member creation should not trigger
loadbalancer security group rules update. This patch ensures the
action is not triggered in such a case.

Change-Id: I0d5f6ffd47fe0a1ae998aa4a61a9240ce0accd40