### PR TITLE
Bug 1810501:  Ensures accurate quota calculation during the readiness checks 

### DIFF
--- a/kuryr_kubernetes/controller/managers/health.py
+++ b/kuryr_kubernetes/controller/managers/health.py
@@ -61,7 +61,7 @@ class HealthServer(object):
     def _components_ready(self):
         os_net = clients.get_network_client()
         project_id = config.CONF.neutron_defaults.project
-        quota = os_net.get_quota(project_id)
+        quota = os_net.get_quota(quota=project_id, details=True)
 
         for component in self._registry:
             if not component.is_ready(quota):

--- a/kuryr_kubernetes/opts.py
+++ b/kuryr_kubernetes/opts.py
@@ -19,9 +19,6 @@ from kuryr_kubernetes import config
 from kuryr_kubernetes.controller.drivers import namespace_subnet
 from kuryr_kubernetes.controller.drivers import utils as driver_utils
 from kuryr_kubernetes.controller.drivers import vif_pool
-from kuryr_kubernetes.controller.handlers import namespace
-from kuryr_kubernetes.controller.handlers import policy
-from kuryr_kubernetes.controller.handlers import vif
 from kuryr_kubernetes.controller.managers import health
 from kuryr_kubernetes.controller.managers import pool
 from kuryr_kubernetes import utils
@@ -42,9 +39,6 @@ _kuryr_k8s_opts = [
     ('cni_health_server', cni_health.cni_health_server_opts),
     ('namespace_subnet', namespace_subnet.namespace_subnet_driver_opts),
     ('sriov', config.sriov_opts),
-    ('namespace_handler_caching', namespace.namespace_handler_caching_opts),
-    ('np_handler_caching', policy.np_handler_caching_opts),
-    ('vif_handler_caching', vif.vif_handler_caching_opts),
     ('pod_ip_caching', driver_utils.pod_ip_caching_opts),
 ]
 

--- a/kuryr_kubernetes/tests/unit/controller/managers/test_health.py
+++ b/kuryr_kubernetes/tests/unit/controller/managers/test_health.py
@@ -23,15 +23,51 @@ from oslo_config import cfg as oslo_cfg
 def get_quota_obj():
     return {
         'quota': {
-            'subnet': 100,
-            'network': 100,
-            'floatingip': 50,
-            'subnetpool': -1,
-            'security_group_rule': 100,
-            'security_group': 10,
-            'router': 10,
-            'rbac_policy': 10,
-            'port': 500
+            'subnet': {
+                'used': 50,
+                'limit': 100,
+                'reserved': 0
+            },
+            'network': {
+                'used': 50,
+                'limit': 100,
+                'reserved': 0
+            },
+            'floatingip': {
+                'used': 25,
+                'limit': 50,
+                'reserved': 0
+            },
+            'subnetpool': {
+                'used': 0,
+                'limit': -1,
+                'reserved': 0
+            },
+            'security_group_rule': {
+                'used': 50,
+                'limit': 100,
+                'reserved': 0
+            },
+            'security_group': {
+                'used': 5,
+                'limit': 10,
+                'reserved': 0
+            },
+            'router': {
+                'used': 5,
+                'limit': 10,
+                'reserved': 0
+            },
+            'rbac_policy': {
+                'used': 5,
+                'limit': 10,
+                'reserved': 0
+            },
+            'port': {
+                'used': 250,
+                'limit': 500,
+                'reserved': 0
+            }
         }
     }
 

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -217,12 +217,11 @@ def extract_pod_annotation(annotation):
 
 def has_limit(quota):
     NO_LIMIT = -1
-    return quota != NO_LIMIT
+    return quota['limit'] != NO_LIMIT
 
 
-def is_available(resource, resource_quota, network_func):
-    qnt_resources = len(list(network_func()))
-    availability = resource_quota - qnt_resources
+def is_available(resource, resource_quota):
+    availability = resource_quota['limit'] - resource_quota['used']
     if availability <= 0:
         LOG.error("Quota exceeded for resource: %s", resource)
         return False

--- a/releasenotes/notes/deprecate-handlers-caching-9cdfd772aba9a7ce.yaml
+++ b/releasenotes/notes/deprecate-handlers-caching-9cdfd772aba9a7ce.yaml
@@ -1,0 +1,9 @@
+---
+deprecations:
+  - |
+    Configuration sections ``[namespace_handler_caching]``,  ``[np_handler_caching]``
+    and ``[vif_handler_caching]`` have been deprecated due to simplifying quota usage
+    calculation for readiness checks. Instead of counting Neutron objects
+    (ports, sg, subnets, and networks), the quota_details extension is used,
+    which includes used, limit and reserved counts per resource.
+    In this way, caching becomes unnecessary.


### PR DESCRIPTION
Current deployments of OpenShift platform with Kuryr CNI
in real OpenStack installations (multi-projects environments)
are crashing because of kuryr-controller cannot come to
READY state.

This is due to inaccurate quota calculations in the readiness
process and an unscalable fetching of objects from Neutron API
to count and comparing with limits.

This commit ensures accurate quota calculation for installation
project during the readiness checks and removes the harsh
Neutron API calls. It will dramatically speedup readiness checks.