### PR TITLE
Bug 1810517: Ensure list of pods items is retrieved

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy_security_groups.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy_security_groups.py
@@ -319,7 +319,7 @@ def _parse_selectors_on_namespace(crd, direction, pod_selector,
                     if sg_rule not in crd_rules:
                         crd_rules.append(sg_rule)
         else:
-            ns_pods = driver_utils.get_pods(ns_selector)
+            ns_pods = driver_utils.get_pods(ns_selector)['items']
             ns_cidr = driver_utils.get_namespace_subnet_cidr(namespace)
             if 'ports' in rule_block:
                 for port in rule_block['ports']:

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy_security_groups.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy_security_groups.py
@@ -573,6 +573,8 @@ class TestNetworkPolicySecurityGroupsDriver(test_base.TestCase):
         m_delete_sg_rule.assert_not_called()
         m_patch_kuryrnetworkpolicy_crd.assert_not_called()
 
+    @mock.patch('kuryr_kubernetes.controller.drivers.utils.'
+                'get_pods')
     @mock.patch('kuryr_kubernetes.controller.drivers.'
                 'network_policy_security_groups._create_sg_rule')
     @mock.patch('kuryr_kubernetes.controller.drivers.utils.'
@@ -580,7 +582,7 @@ class TestNetworkPolicySecurityGroupsDriver(test_base.TestCase):
     @mock.patch('kuryr_kubernetes.controller.drivers.utils.'
                 'get_namespace_subnet_cidr')
     def test__parse_rules(self, m_get_ns_subnet_cidr, m_match_selector,
-                          m_create_sg_rule):
+                          m_create_sg_rule, m_get_pods):
         crd = get_crd_obj_no_match()
         policy = crd['spec']['networkpolicy_spec']
         i_rule = policy.get('ingress')[0]


### PR DESCRIPTION
Right now we attempt to retrieve the list of pods without
fetching the items field returned on the kubernetes response,
causing the wrong element to be fetched.

This commit fixes the issue by getting the list of pods
through the items.
