### PR TITLE
Bug 1810571: Raise K8sResourceNotFound for all client methods

### DIFF
--- a/kuryr_kubernetes/tests/unit/test_k8s_client.py
+++ b/kuryr_kubernetes/tests/unit/test_k8s_client.py
@@ -434,3 +434,23 @@ class TestK8sClient(test_base.TestCase):
 
         self.assertRaises(exc.K8sClientException,
                           self.client.delete, path)
+
+    def test__raise_from_response(self):
+        m_resp = mock.MagicMock()
+        m_resp.ok = True
+        m_resp.status_code = 202
+        self.client._raise_from_response(m_resp)
+
+    def test__raise_from_response_404(self):
+        m_resp = mock.MagicMock()
+        m_resp.ok = False
+        m_resp.status_code = 404
+        self.assertRaises(exc.K8sResourceNotFound,
+                          self.client._raise_from_response, m_resp)
+
+    def test__raise_from_response_500(self):
+        m_resp = mock.MagicMock()
+        m_resp.ok = False
+        m_resp.status_code = 500
+        self.assertRaises(exc.K8sClientException,
+                          self.client._raise_from_response, m_resp)


### PR DESCRIPTION
Seems like K8sClient wasn't raising K8sResourceNotFound exception on 404
from all the methods, e.g. patch. This commit makes sure that is no
longer the case and any 404 results in K8sResourceNotFound exception.
