### PR TITLE
Bug 1810574: Nested CNI: Remove interfaces on DEL requests

### DIFF
--- a/kuryr_kubernetes/tests/unit/cni/test_binding.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_binding.py
@@ -97,8 +97,13 @@ class TestDriverMixin(test_base.TestCase):
         if report:
             report.assert_called_once()
 
+    @mock.patch('kuryr_kubernetes.cni.binding.base.get_ipdb')
     @mock.patch('os_vif.unplug')
-    def _test_disconnect(self, m_vif_unplug, report=None):
+    def _test_disconnect(self, m_vif_unplug, m_get_ipdb, report=None):
+        def get_ipdb(netns=None):
+            return self.ipdbs[netns]
+        m_get_ipdb.side_effect = get_ipdb
+
         base.disconnect(self.vif, self.instance_info, self.ifname, self.netns,
                         report)
         m_vif_unplug.assert_called_once_with(self.vif, self.instance_info)


### PR DESCRIPTION
Historically we haven't been doing any actions on CNI DEL request when
running in nested mode because all the interfaces we created will be
gone when netns will get deleted. There is an issue with that approach:

1. We get ADD request for pod A in netns X and correctly bind it using
   VLAN ID V.
2. We get DEL request for same pod A and netns X. We don't do anything.
3. Netns is not yet deleted…
4. Another ADD request comes for pod A but now with netns Y (normal K8s
   behavior).
   a) We try binding it, but there is a veth pair with VLAN ID V already
   on the host namespace, so we end up with VLAN ID conflict.
   b) Binding fails with EEXIST error.

The problem with this hypothesis is that the EEXIST error seems to be
persistent and in theory it should disappear after the netns gets
deleted but maybe there's a longer delay in the netns deletion.

This commit solves this problem by making sure we always clean up all
interfaces on DEL requests.