### PR TITLE
Kuryr: Add apiVersion and kind to AC reponse

### DIFF
--- a/kuryr_kubernetes/cmd/webhook_server.py
+++ b/kuryr_kubernetes/cmd/webhook_server.py
@@ -84,16 +84,18 @@ def webhook():
         patch_str = base64.b64encode(str(patch).encode()).decode()
 
     admission_review = {
+        'apiVersion': request_info['apiVersion'],
+        'kind': request_info['kind'],
         'response': {
             'allowed': True,
             'uid': request_info['request']['uid'],
-        }
+        },
     }
 
     if patch_str:
         admission_review['response'].update({
             'patch': patch_str,
-            'patchtype': 'JSONPatch',
+            'patchType': 'JSONPatch',
         })
 
     return jsonify(admission_review)


### PR DESCRIPTION
Kuryr's webhook is now updated to use stable API. In that version the
validation of the webhook's response is more strict and we need to
return correct apiVersion and kind along with the response. This commit
makes sure we do that.