### PR TITLE
Bug 1818067:Ensure no attempt to deleted sg rules owned by Octavia happens

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -200,7 +200,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
             return
 
         lbaas_sg_rules = neutron.list_security_group_rules(
-            security_group_id=lb_sg)
+            security_group_id=lb_sg, project_id=loadbalancer.project_id)
         all_pod_rules = []
         add_default_rules = False
 


### PR DESCRIPTION
When updating the LB security group with only the rules applied
on a Network Policy we are also considering the sg rules owned by
octavia, this result on failure when trying to delete the rules
as this operation is not allowed.