### PR TITLE
Bug 1826770: Update the Kuryr images to 4.5 repos

### DIFF
--- a/openshift-kuryr-cni-ci-rhel8.Dockerfile
+++ b/openshift-kuryr-cni-ci-rhel8.Dockerfile
@@ -30,5 +30,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-cni" \
         io.k8s.display-name="kuryr-cni" \
-        version="4.4.0" \
+        version="4.5.0" \
         com.redhat.component="kuryr-cni-container"

--- a/openshift-kuryr-cni-rhel8.Dockerfile
+++ b/openshift-kuryr-cni-rhel8.Dockerfile
@@ -26,5 +26,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-cni" \
         io.k8s.display-name="kuryr-cni" \
-        version="4.4.0" \
+        version="4.5.0" \
         com.redhat.component="kuryr-cni-container"

--- a/openshift-kuryr-controller-ci-rhel8.Dockerfile
+++ b/openshift-kuryr-controller-ci-rhel8.Dockerfile
@@ -19,5 +19,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-controller" \
         io.k8s.display-name="kuryr-controller" \
-        version="4.4.0" \
+        version="4.5.0" \
         com.redhat.component="kuryr-controller-container"

--- a/openshift-kuryr-controller-rhel8.Dockerfile
+++ b/openshift-kuryr-controller-rhel8.Dockerfile
@@ -15,5 +15,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-controller" \
         io.k8s.display-name="kuryr-controller" \
-        version="4.4.0" \
+        version="4.5.0" \
         com.redhat.component="kuryr-controller-container"

--- a/openshift-kuryr-kubernetes-rhel8.spec
+++ b/openshift-kuryr-kubernetes-rhel8.spec
@@ -13,7 +13,7 @@ with OpenStack networking.
 %global commit 0000000
 
 Name:      openshift-%project
-Version:   4.4.1
+Version:   4.5.1
 Release:   1%{?dist}
 Summary:   OpenStack networking integration with OpenShift and Kubernetes
 License:   ASL 2.0
@@ -58,7 +58,6 @@ Requires:       python3-oslo-serialization >= 2.18.0
 Requires:       python3-oslo-service >= 1.24.0
 Requires:       python3-oslo-utils >= 3.33.0
 Requires:       python3-os-vif >= 1.7.0
-Requires:       python3-six >= 1.10.0
 Requires:       python3-stevedore >= 1.20.0
 Requires:       python3-cotyledon >= 1.5.0
 Requires:       python3-flask >= 0.12.3

--- a/openshift-kuryr-tester-rhel8.Dockerfile
+++ b/openshift-kuryr-tester-rhel8.Dockerfile
@@ -12,5 +12,5 @@ LABEL \
         maintainer="Michal Dulko <mdulko@redhat.com>" \
         name="openshift/kuryr-tester" \
         io.k8s.display-name="kuryr-tester" \
-        version="4.4.0" \
+        version="4.5.0" \
         com.redhat.component="kuryr-tester-container"

--- a/tools/build-rpm-rhel8.sh
+++ b/tools/build-rpm-rhel8.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-version=4.4.1
+version=4.5.1
 source_path=_output/SOURCES
 
 mkdir -p ${source_path}


### PR DESCRIPTION
Current dev release is 4.5 so we should use 4.5 repos by default.