### PR TITLE
Bug 1828387: Ensure NP are enforced on SVC with different port and target port

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -809,7 +809,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
             lbaas_port = port['port']
             target_port = port['targetPort']
             sg_rule_name = "%s:%s:%s" % (lbaas_name, port_protocol, lbaas_port)
-            listener_id = lsnr_ids.get((port_protocol, target_port))
+            listener_id = lsnr_ids.get((port_protocol, lbaas_port))
             if listener_id is None:
                 LOG.warning("There is no listener associated to the protocol "
                             "%s and port %s. Skipping", port_protocol,


### PR DESCRIPTION
This patch ensure the proper listener id is found and its associated
security groups are updated.

Change-Id: I72120c33debddfe6ba29c8c0152a0cef4e96a6eb
Closes-Bug: 1875428