### PR TITLE
Namespace SG driver: remove default egress rules

### DIFF
--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_namespace_security_groups.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_namespace_security_groups.py
@@ -221,7 +221,7 @@ class TestNamespacePodSecurityGroupsDriver(test_base.TestCase):
 
         namespace = 'test'
         project_id = mock.sentinel.project_id
-        sg = {'id': mock.sentinel.sg}
+        sg = {'id': mock.sentinel.sg, 'security_group_rules': []}
         subnet_cidr = mock.sentinel.subnet_cidr
         crd_spec = {
             'subnetCIDR': subnet_cidr


### PR DESCRIPTION
Namespace isolation does not handle egress, so there is no need
to keep the egress rules on the namespace associated security
groups. This is left to the default SG group and or to the customer
to modified the needed SG egress rules on the namespaces as needed.

It also adds the possibility of not only have the "default" namespace
as exception for the isolation.
