### PR TITLE
Bug 1836187: Fix Kuryr CI for 3.11 branch

### DIFF
--- a/openshift-kuryr-tester.Dockerfile
+++ b/openshift-kuryr-tester.Dockerfile
@@ -6,8 +6,9 @@ RUN yum update -y \
  && yum install -y python-devel python-pbr python-pip \
  && yum clean all \
  && rm -rf /var/cache/yum \
+ && pip install -U pip \
  && pip install "more-itertools<6.0.0" tox
-# more-itertools 6.0.0 drops support for Python 2.7, so we need to ensure we have older version.
+ # more-itertools 6.0.0 drops support for Python 2.7, so we need to ensure we have older version.
 
 LABEL \
         io.k8s.description="This is a component of OpenShift Container Platform and provides a testing container for Kuryr service." \

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ passenv = HOME
 setenv = VIRTUAL_ENV={envdir}
 usedevelop = True
 install_command = pip install {opts} {packages}
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://opendev.org/openstack/requirements/raw/branch/master/upper-constraints.txt}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://opendev.org/openstack/requirements/raw/branch/stable/stein/upper-constraints.txt}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 whitelist_externals = sh


### PR DESCRIPTION
This commit pins the dependecies to Stein release, as the controller
image also uses it, and upgrades pip.