### PR TITLE
Bug 1838116: Ignore FileNotFoundError on CNI DEL

### DIFF
--- a/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
+++ b/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
@@ -99,7 +99,12 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
                 return
         except KeyError:
             pass
-        self._do_work(params, b_base.disconnect)
+
+        try:
+            self._do_work(params, b_base.disconnect)
+        except FileNotFoundError as e:
+            LOG.warning('File %s not found. Most likely network namespace is '
+                        'already gone. Ignoring.', e.filename)
         # NOTE(ndesh): We need to lock here to avoid race condition
         #              with the deletion code in the watcher to ensure that
         #              we delete the registry entry exactly once


### PR DESCRIPTION
Apparently there's a race condition in cri-o that may result in CNI
requests being sent when network namespace is already deleted. While
this is clear violation of CNI spec, this commit adds some protection
from it and makes sure the error is ignored if it happens on DEL
request, as it should be safe. We do not add it to CNI ADD, as in such
case it would be us violating CNI spec.