### PR TITLE
Bug 1838985:Skip LB sg update when no endpoint is found

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -790,7 +790,12 @@ class LBaaSv2Driver(base.LBaaSDriver):
 
         endpoints_link = utils.get_endpoints_link(service)
         k8s = clients.get_kubernetes_client()
-        endpoint = k8s.get(endpoints_link)
+        try:
+            endpoint = k8s.get(endpoints_link)
+        except k_exc.K8sResourceNotFound:
+            LOG.debug("Endpoint not Found. Skipping LB SG update for"
+                      "%s as the LB resources are not present", lbaas_name)
+            return
 
         lbaas = utils.get_lbaas_state(endpoint)
         if not lbaas:


### PR DESCRIPTION
When a pod event is handled it's possible that a Network Policy and Service
are affected by that pod and the LB sg of selected services needs to be
updated. However, the endpoints for the matched service may not be yet
present or were deleted, resulting in a NotFound exception.
This commit handled this exception by skipping the LB sg update.

Change-Id: I21a4d6cb515633d47b534f180517687d07b8f83f
Closes-bug: 1876666