### PR TITLE
Bug 1838997: Fix hacking min version to 3.0.1

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking>=2.0.0 # Apache-2.0
+hacking>=3.0.1,<3.1.0 # Apache-2.0
 
 coverage!=4.4,>=4.0 # Apache-2.0
 ddt>=1.0.1 # MIT


### PR DESCRIPTION
flake8 new release 3.8.0 added new checks and gate pep8
job start failing. hacking 3.0.1 fix the pinning of flake8 to
avoid bringing in a new version with new checks.

Though it is fixed in latest hacking but 2.0 and 3.0 has cap for
flake8 as <4.0.0 which mean flake8 new version 3.9.0 can also
break the pep8 job if new check are added.

To avoid similar gate break in future, we need to bump the hacking min
version.

- http://lists.openstack.org/pipermail/openstack-discuss/2020-May/014828.html

Change-Id: I54d3d778266d840bd724836018340d9bd3987844