### PR TITLE
Bug 1840187:Ensure LB resources with ERROR status are deleted

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -132,8 +132,8 @@ class LBaaSv2Driver(base.LBaaSDriver):
         request = obj_lbaas.LBaaSLoadBalancer(
             name=name, project_id=project_id, subnet_id=subnet_id, ip=ip,
             security_groups=security_groups_ids, provider=provider)
-        response = self._ensure(request, self._create_loadbalancer,
-                                self._find_loadbalancer)
+        response = self._ensure(self._create_loadbalancer,
+                                self._find_loadbalancer, request)
         if not response:
             # NOTE(ivc): load balancer was present before 'create', but got
             # deleted externally between 'create' and 'find'
@@ -568,7 +568,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
             LOG.exception('Error when updating listener %s' % listener_id)
             raise k_exc.ResourceNotReady(listener_id)
 
-    def _find_listener(self, listener):
+    def _find_listener(self, listener, loadbalancer):
         lbaas = clients.get_loadbalancer_client()
         response = lbaas.listeners(
             name=listener.name,
@@ -580,6 +580,10 @@ class LBaaSv2Driver(base.LBaaSDriver):
         try:
             os_listener = next(response)
             listener.id = os_listener.id
+            if os_listener.provisioning_status == 'ERROR':
+                LOG.debug("Releasing listener %s", os_listener.id)
+                self.release_listener(loadbalancer, listener)
+                return None
         except (KeyError, StopIteration):
             return None
 
@@ -602,7 +606,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
         pool.id = response.id
         return pool
 
-    def _find_pool(self, pool, by_listener=True):
+    def _find_pool(self, pool, loadbalancer, by_listener=True):
         lbaas = clients.get_loadbalancer_client()
         response = lbaas.pools(
             name=pool.name,
@@ -616,14 +620,17 @@ class LBaaSv2Driver(base.LBaaSDriver):
                          in {l['id'] for l in p.listeners}]
             else:
                 pools = [p for p in response if pool.name == p.name]
-
             pool.id = pools[0].id
+            if pools[0].provisioning_status == 'ERROR':
+                LOG.debug("Releasing pool %s", pool.id)
+                self.release_pool(loadbalancer, pool)
+                return None
         except (KeyError, IndexError):
             return None
         return pool
 
-    def _find_pool_by_name(self, pool):
-        return self._find_pool(pool, by_listener=False)
+    def _find_pool_by_name(self, pool, loadbalancer):
+        return self._find_pool(pool, loadbalancer, by_listener=False)
 
     def _create_member(self, member):
         request = {
@@ -639,7 +646,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
         member.id = response.id
         return member
 
-    def _find_member(self, member):
+    def _find_member(self, member, loadbalancer):
         lbaas = clients.get_loadbalancer_client()
         response = lbaas.members(
             member.pool_id,
@@ -650,23 +657,27 @@ class LBaaSv2Driver(base.LBaaSDriver):
             protocol_port=member.port)
 
         try:
-            member.id = next(response).id
+            os_members = next(response)
+            member.id = os_members.id
+            if os_members.provisioning_status == 'ERROR':
+                LOG.debug("Releasing Member %s", os_members.id)
+                self.release_member(loadbalancer, member)
+                return None
         except (KeyError, StopIteration):
             return None
 
         return member
 
-    def _ensure(self, obj, create, find):
+    def _ensure(self, create, find, *args):
         okay_codes = (409, 500)
         try:
-            result = create(obj)
+            result = create(args[0])
             LOG.debug("Created %(obj)s", {'obj': result})
             return result
         except os_exc.HttpException as e:
             if e.status_code not in okay_codes:
                 raise
-
-        result = find(obj)
+        result = find(*args)
         if result:
             LOG.debug("Found %(obj)s", {'obj': result})
         return result
@@ -677,7 +688,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
                                                   interval):
             self._wait_for_provisioning(loadbalancer, remaining, interval)
             try:
-                result = self._ensure(obj, create, find)
+                result = self._ensure(create, find, obj, loadbalancer)
                 if result:
                     return result
             except os_exc.BadRequestException:

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
@@ -125,10 +125,10 @@ class TestLBaaSv2Driver(test_base.TestCase):
         os_net.update_port = mock.Mock()
         resp = cls.ensure_loadbalancer(m_driver, lb_name, project_id,
                                        subnet_id, ip, sg_ids, 'ClusterIP')
-        m_driver._ensure.assert_called_once_with(mock.ANY,
-                                                 m_driver._create_loadbalancer,
-                                                 m_driver._find_loadbalancer)
-        req = m_driver._ensure.call_args[0][0]
+        m_driver._ensure.assert_called_once_with(m_driver._create_loadbalancer,
+                                                 m_driver._find_loadbalancer,
+                                                 mock.ANY)
+        req = m_driver._ensure.call_args[0][2]
         self.assertEqual(lb_name, req.name)
         self.assertEqual(project_id, req.project_id)
         self.assertEqual(subnet_id, req.subnet_id)
@@ -499,13 +499,15 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer(
+            id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         listener = obj_lbaas.LBaaSListener(
             name='TEST_NAME', project_id='TEST_PROJECT', protocol='TCP',
             port=1234, loadbalancer_id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         listener_id = 'A57B7771-6050-4CA8-A63C-443493EC98AB'
         lbaas.listeners.return_value = iter([o_lis.Listener(id=listener_id)])
 
-        ret = cls._find_listener(m_driver, listener)
+        ret = cls._find_listener(m_driver, listener, loadbalancer)
         lbaas.listeners.assert_called_once_with(
             name=listener.name,
             project_id=listener.project_id,
@@ -521,13 +523,15 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer(
+            id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         listener = obj_lbaas.LBaaSListener(
             name='TEST_NAME', project_id='TEST_PROJECT', protocol='TCP',
             port=1234, loadbalancer_id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         resp = iter([])
         lbaas.listeners.return_value = resp
 
-        ret = cls._find_listener(m_driver, listener)
+        ret = cls._find_listener(m_driver, listener, loadbalancer)
         lbaas.listeners.assert_called_once_with(
             name=listener.name,
             project_id=listener.project_id,
@@ -620,6 +624,8 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer(
+            id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         pool = obj_lbaas.LBaaSPool(
             name='TEST_NAME', project_id='TEST_PROJECT', protocol='TCP',
             listener_id='A57B7771-6050-4CA8-A63C-443493EC98AB',
@@ -629,7 +635,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
                             listeners=[{"id": pool.listener_id}])]
         lbaas.pools.return_value = resp
 
-        ret = cls._find_pool(m_driver, pool)
+        ret = cls._find_pool(m_driver, pool, loadbalancer)
         lbaas.pools.assert_called_once_with(
             name=pool.name,
             project_id=pool.project_id,
@@ -644,6 +650,8 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer(
+            id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         pool = obj_lbaas.LBaaSPool(
             name='TEST_NAME', project_id='TEST_PROJECT', protocol='TCP',
             listener_id='A57B7771-6050-4CA8-A63C-443493EC98AB',
@@ -651,7 +659,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         resp = []
         lbaas.pools.return_value = resp
 
-        ret = cls._find_pool(m_driver, pool)
+        ret = cls._find_pool(m_driver, pool, loadbalancer)
         lbaas.pools.assert_called_once_with(
             name=pool.name,
             project_id=pool.project_id,
@@ -688,6 +696,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer()
         member = obj_lbaas.LBaaSMember(
             name='TEST_NAME', project_id='TEST_PROJECT', ip='1.2.3.4',
             port=1234, subnet_id='D3FA400A-F543-4B91-9CD3-047AF0CE42D1',
@@ -696,7 +705,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         resp = iter([o_mem.Member(id=member_id)])
         lbaas.members.return_value = resp
 
-        ret = cls._find_member(m_driver, member)
+        ret = cls._find_member(m_driver, member, loadbalancer)
         lbaas.members.assert_called_once_with(
             member.pool_id,
             name=member.name,
@@ -713,6 +722,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer()
         member = obj_lbaas.LBaaSMember(
             name='TEST_NAME', project_id='TEST_PROJECT', ip='1.2.3.4',
             port=1234, subnet_id='D3FA400A-F543-4B91-9CD3-047AF0CE42D1',
@@ -720,7 +730,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         resp = iter([])
         lbaas.members.return_value = resp
 
-        ret = cls._find_member(m_driver, member)
+        ret = cls._find_member(m_driver, member, loadbalancer)
         lbaas.members.assert_called_once_with(
             member.pool_id,
             name=member.name,
@@ -739,7 +749,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         expected_result = mock.sentinel.expected_result
         m_create.return_value = expected_result
 
-        ret = cls._ensure(m_driver, obj, m_create, m_find)
+        ret = cls._ensure(m_driver, m_create, m_find, obj)
         m_create.assert_called_once_with(obj)
         self.assertEqual(expected_result, ret)
 
@@ -753,7 +763,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         m_create.side_effect = exception_value
         m_find.return_value = expected_result
 
-        ret = cls._ensure(m_driver, obj, m_create, m_find)
+        ret = cls._ensure(m_driver, m_create, m_find, obj)
         m_create.assert_called_once_with(obj)
         m_find.assert_called_once_with(obj)
         self.assertEqual(expected_result, ret)
@@ -785,7 +795,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
             [mock.call(loadbalancer, t, d_lbaasv2._LB_STS_POLL_FAST_INTERVAL)
              for t in timer])
         m_driver._ensure.assert_has_calls(
-            [mock.call(obj, create, find) for _ in timer])
+            [mock.call(create, find, obj, loadbalancer) for _ in timer])
 
     def test_ensure_not_ready(self):
         cls = d_lbaasv2.LBaaSv2Driver
@@ -806,7 +816,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
             [mock.call(loadbalancer, t, d_lbaasv2._LB_STS_POLL_FAST_INTERVAL)
              for t in timer])
         m_driver._ensure.assert_has_calls(
-            [mock.call(obj, create, find) for _ in timer])
+            [mock.call(create, find, obj, loadbalancer) for _ in timer])
 
     def test_release(self):
         cls = d_lbaasv2.LBaaSv2Driver


### PR DESCRIPTION
In case a LB resource ends up with ERROR in the provisioning status
we must ensure the deletion and recreation of the resource.

Closes-bug: 1879371
Change-Id: I2531948ab6181cfa5049b54c78935c23f60173d2