### PR TITLE
Bug 1839180: Remove lb sg creation when octavia provider is ovn-octavia

### DIFF
--- a/kuryr_kubernetes/config.py
+++ b/kuryr_kubernetes/config.py
@@ -241,7 +241,10 @@ octavia_defaults = [
                help=_("Define the LBaaS SG policy."),
                choices=[('create', 'replace the VIP SG with a new one'),
                         ('update', 'add rules to the existing VIP SG')],
-               default='update'),
+               default='update',
+               deprecated_for_removal=True,
+               deprecated_reason="enforce_sg_rules option can be used"
+                                 " instead"),
     cfg.BoolOpt('enforce_sg_rules',
                 help=_("Enable the enforcement of SG rules at the LB SG "
                        "in case the LB does not maintain the source IP "

--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -300,11 +300,13 @@ class LoadBalancerHandler(k8s_base.ResourceEventHandler):
     def _add_new_members(self, endpoints, lbaas_state, lbaas_spec):
         changed = False
 
-        try:
-            self._sync_lbaas_sgs(endpoints, lbaas_state)
-        except k_exc.K8sResourceNotFound:
-            LOG.debug("The svc has been deleted while processing the endpoints"
-                      " update. No need to add new members.")
+        if config.CONF.octavia_defaults.enforce_sg_rules:
+            try:
+                self._sync_lbaas_sgs(endpoints, lbaas_state)
+            except k_exc.K8sResourceNotFound:
+                LOG.debug("The svc has been deleted while processing"
+                          " the endpoints update. No need to add new"
+                          " members.")
 
         lsnr_by_id = {l.id: l for l in lbaas_state.listeners}
         pool_by_lsnr_port = {(lsnr_by_id[p.listener_id].protocol,

--- a/releasenotes/notes/deprecate-sg-mode-option-96824c33335cd74b.yaml
+++ b/releasenotes/notes/deprecate-sg-mode-option-96824c33335cd74b.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    Setting the ``sg_mode`` option for octavia is being deprecated.
+    Main reason is that when ``sg_mode`` is create a new load balancer
+    security group is created. However, when ovn-octavia provider is
+    used that security group is not enforced, and thus there is no
+    need to have been created.
+    To address the other operation handled on this config, the
+    ``enforce_sg_rules`` config can be used instead.


### PR DESCRIPTION
When deleting services and the respective load balancer
with using ovn-octavia provider, the lb sg is not deleted.
This commit fixes the issue by removing the LB sg creation
when the octavia provider is ovn-octavia, as that sg is not
really enforced.

Closes-bug: 1880207
Change-Id: I2c77b1d0ac682008ff6c31781d6075c208c689d0