### PR TITLE
Bug 1841846: Ensure kuryrnetwork CRs without status can be deleted

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrnetwork.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetwork.py
@@ -92,7 +92,7 @@ class KuryrNetworkHandler(k8s_base.ResourceEventHandler):
     def on_finalize(self, kuryrnet_crd):
         LOG.debug("Deleting kuryrnetwork CRD resources: %s", kuryrnet_crd)
 
-        net_id = kuryrnet_crd['status'].get('netId')
+        net_id = kuryrnet_crd.get('status', {}).get('netId')
         if net_id:
             self._drv_vif_pool.delete_network_pools(
                 kuryrnet_crd['status']['netId'])


### PR DESCRIPTION
This patch ensures if on_finalize event for a CR is processed before
its status got populated, it is still possible to remove its finalizer
and unblock the namespace deletion.

Change-Id: I338ad6967f96807431754e91d2c1f9031723ec8e
Closes-Bug: 1881318