### PR TITLE
Bug 1843674: Ensure security_groups on LBaaSLoadBalancer defaults to empty list

### DIFF
--- a/kuryr_kubernetes/objects/lbaas.py
+++ b/kuryr_kubernetes/objects/lbaas.py
@@ -26,7 +26,8 @@ class LBaaSLoadBalancer(k_obj.KuryrK8sObjectBase):
     # Version 1.1: Added provider field and security_groups field.
     # Version 1.2: Added support for security_groups=None
     # Version 1.3: Added support for provider=None
-    VERSION = '1.3'
+    # Version 1.4: Added support for security_groups=[]
+    VERSION = '1.4'
 
     fields = {
         'id': obj_fields.UUIDField(),
@@ -38,7 +39,7 @@ class LBaaSLoadBalancer(k_obj.KuryrK8sObjectBase):
         'provider': obj_fields.StringField(nullable=True,
                                            default=None),
         'security_groups': k_fields.ListOfUUIDField(nullable=True,
-                                                    default=None),
+                                                    default=[]),
     }
 
 

--- a/kuryr_kubernetes/tests/unit/test_object.py
+++ b/kuryr_kubernetes/tests/unit/test_object.py
@@ -22,7 +22,7 @@ from oslo_versionedobjects import fixture
 # objects
 object_data = {
     'LBaaSListener': '1.0-a9e2d5c73687f5edc66fdb2f48650e15',
-    'LBaaSLoadBalancer': '1.3-8bc0a9bdbd160da67572aa38784378d1',
+    'LBaaSLoadBalancer': '1.4-835c38599fa4692ad26726342c36ccb4',
     'LBaaSMember': '1.0-a770c6884c27d6d8c21186b27d0e2ccb',
     'LBaaSPool': '1.1-6e77370d7632a902445444249eb77b01',
     'LBaaSPortSpec': '1.1-1b307f34630617086c7af70f2cb8b215',


### PR DESCRIPTION
When no security groups is present on the LBaaSLoadBalancer oslo
versioned object it should default to an empty list and not to
None. Otherwise iterations of the security_groups field fails.

Closes-bug: 1881575

Change-Id: I9a98584f80219bf5c2ea414177826a26470d414f