### PR TITLE
Bug 1845923: Get RPM and Kuryr version from git

### DIFF
--- a/openshift-kuryr-kubernetes-rhel8.spec
+++ b/openshift-kuryr-kubernetes-rhel8.spec
@@ -13,8 +13,8 @@ with OpenStack networking.
 %global commit 0000000
 
 Name:      openshift-%project
-Version:   4.3.1
-Release:   1%{?dist}
+Version:   %{_version}
+Release:   %{_release}%{?dist}
 Summary:   OpenStack networking integration with OpenShift and Kubernetes
 License:   ASL 2.0
 URL:       http://docs.openstack.org/developer/kuryr-kubernetes/
@@ -107,6 +107,11 @@ find %{module} -name \*.py -exec sed -i '/\/usr\/bin\/env python/{d;q}' {} +
 rm -f requirements.txt
 rm -f test-requirements.txt
 rm -f doc/requirements.txt
+
+# Need to commit it to make sure no .devxyz will get added to version by pbr.
+git commit -a --amend -m "Manage requirements on our own"
+# Tagging will make sure pbr uses this as version.
+git tag -a -m "%{version}" "%{version}"
 
 # Kill egg-info in order to generate new SOURCES.txt
 rm -rf kuryr_kubernetes.egg-info

--- a/tools/build-rpm-rhel8.sh
+++ b/tools/build-rpm-rhel8.sh
@@ -1,14 +1,19 @@
 #!/bin/bash -x
 
-version=4.3.1
 source_path=_output/SOURCES
 
 mkdir -p ${source_path}
 
+# Getting version from last tag in git
+version=`git describe --tags --abbrev=0`
+version=${version#openshift-kuryr-} # remove prefix
+release=${version#*-} # remove prefix
+version=${version%-*} # remove date suffix
+
 # NOTE(dulek): rpmbuild requires that inside the tar there will be a
 #              ${service}-${version} directory, hence this --transform option.
-#              Also note that for some reason it doesn't work without excluding
-#              .git directory. Excluding .tox is convenient for local builds.
+#              We exclude .git as rpmbuild will do its own `git init`.
+#              Excluding .tox is convenient for local builds.
 tar -czvf ${source_path}/kuryr-kubernetes.tar.gz --exclude=.git --exclude=.tox --transform "flags=r;s|\.|kuryr-kubernetes-${version}|" .
 cp kuryr.logrotate ${source_path}
 cp kuryr-controller.service ${source_path}
@@ -20,5 +25,5 @@ curl http://base-openstack-4-3.ocp.svc > /etc/yum.repos.d/base-openstack-4-3.rep
 
 yum install -y python3-pbr python3-devel
 
-rpmbuild -ba -D "_topdir `pwd`/_output" openshift-kuryr-kubernetes-rhel8.spec
+rpmbuild -ba -D "_version $version" -D "_release $release" -D "_topdir `pwd`/_output" openshift-kuryr-kubernetes-rhel8.spec
 createrepo _output/RPMS/noarch


### PR DESCRIPTION
This commit makes sure we're getting the version to use as RPM and
Python package semver from the last tag in git. This should solve issue
of `kuryr-k8s-controller --version` returning 0.0.0 and remove the need
to update versions in various places each time master gets opened to new
release development.