### PR TITLE
Bug 1779163: CNI: Don't wait for missing pods on DEL

### DIFF
--- a/kuryr_kubernetes/cni/binding/nested.py
+++ b/kuryr_kubernetes/cni/binding/nested.py
@@ -79,17 +79,12 @@ class NestedDriver(health.HealthHandler, b_base.BaseBindingDriver):
                 # NOTE(dulek): This is related to bug 1854928. It's super-rare,
                 #              so aim of this piece is to gater any info useful
                 #              for determining when it happens.
-                LOG.exception('Creation of pod interface failed, most likely '
-                              'due to duplicated VLAN id. This will probably '
-                              'cause kuryr-daemon to crashloop. Trying to '
-                              'gather debugging information.')
-
-                with b_base.get_ipdb() as h_ipdb:
-                    LOG.error('List of host interfaces: %s', h_ipdb.interfaces)
-
-                with b_base.get_ipdb(netns) as c_ipdb:
-                    LOG.error('List of pod namespace interfaces: %s',
-                              c_ipdb.interfaces)
+                LOG.exception(f'Creation of pod interface failed due to VLAN '
+                              f'ID (vlan_info={args}) conflict. Probably the '
+                              f'CRI had not cleaned up the network namespace '
+                              f'of deleted pods. This should not be a '
+                              f'permanent issue but may cause restart of '
+                              f'kuryr-cni pod.')
             raise
 
         with b_base.get_ipdb(netns) as c_ipdb:

--- a/kuryr_kubernetes/cni/daemon/service.py
+++ b/kuryr_kubernetes/cni/daemon/service.py
@@ -103,10 +103,10 @@ class DaemonServer(object):
             self.plugin.delete(params)
         except exceptions.ResourceNotReady:
             # NOTE(dulek): It's better to ignore this error - most of the time
-            #              it will happen when pod is long gone and kubelet
+            #              it will happen when pod is long gone and CRI
             #              overzealously tries to delete it from the network.
             #              We cannot really do anything without VIF annotation,
-            #              so let's just tell kubelet to move along.
+            #              so let's just tell CRI to move along.
             LOG.warning('Error when processing delNetwork request. '
                         'Ignoring this error, pod is most likely gone')
             return '', httplib.NO_CONTENT, self.headers


### PR DESCRIPTION
We've seen some issues related to the fact that on CNI DEL we wait for
pod annotation to appear in CNI registry:

1. Overloaded kuryr-daemon HTTP server, because many stale DEL requests
   from CRI will saturate the number of free connections, causing CNI to
   answer requests extremely slowly.
2. Some CRI's will not delete network namespace before getting a
   successful CNI DEL. If we'll assign the same IP (or vlan) to a next
   pod, we might end up with an IP or vlan conflict and NetlinkError.

This commit makes sure we only wait for VIFs up to 5 seconds on DEL
requests, enough time for watcher to populate registry on restart. Also
some code got moved around to make implementating the above simpler and
some logs got clarified to make debugging of such issues easier later
on.

Change-Id: I9221b6bc9166597837a4b53382862aa6c6f3e94c
Closes-Bug: 1882083
Related-Bug: 1854928