### PR TITLE
Bug 1846862: Add support for amphora to ovn-octavia upgrade

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -143,7 +143,6 @@ class LBaaSv2Driver(base.LBaaSDriver):
         return response
 
     def release_loadbalancer(self, loadbalancer):
-        os_net = clients.get_network_client()
         lbaas = clients.get_loadbalancer_client()
         self._release(
             loadbalancer,
@@ -152,15 +151,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
             loadbalancer.id,
             cascade=True)
 
-        sg_id = self._find_listeners_sg(loadbalancer)
-        if sg_id:
-            # Note: reusing activation timeout as deletion timeout
-            self._wait_for_deletion(loadbalancer, _ACTIVATION_TIMEOUT)
-            try:
-                os_net.delete_security_group(sg_id)
-            except os_exc.SDKException:
-                LOG.exception('Error when deleting loadbalancer security '
-                              'group. Leaving it orphaned.')
+        self._wait_for_deletion(loadbalancer, _ACTIVATION_TIMEOUT)
 
     def _create_listeners_acls(self, loadbalancer, port, target_port,
                                protocol, lb_sg, new_sgs, listener_id):
@@ -735,26 +726,6 @@ class LBaaSv2Driver(base.LBaaSDriver):
                 interval = min(interval, timer.leftover())
                 if interval:
                     time.sleep(interval)
-
-    def _find_listeners_sg(self, loadbalancer):
-        os_net = clients.get_network_client()
-        try:
-            sgs = os_net.security_groups(name=loadbalancer.name,
-                                         project_id=loadbalancer.project_id)
-            for sg in sgs:
-                try:
-                    if sg.id in loadbalancer.security_groups:
-                        return sg.id
-                except TypeError:
-                    LOG.exception('Loadbalancer %s does not have '
-                                  'security_groups defined.',
-                                  loadbalancer.name)
-                    raise
-        except os_exc.SDKException:
-            LOG.exception('Cannot list security groups for loadbalancer %s.',
-                          loadbalancer.name)
-
-        return None
 
     def update_lbaas_sg(self, service, sgs):
         LOG.debug('Setting SG for LBaaS VIP port')

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_lbaas.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_lbaas.py
@@ -458,6 +458,7 @@ class TestLoadBalancerHandler(test_base.TestCase):
         m_get_lbaas_state.return_value = lbaas_state
         m_handler._sync_lbaas_members.return_value = True
         m_handler._drv_service_pub_ip = m_drv_service_pub_ip
+        m_handler._lb_provider = None
 
         h_lbaas.LoadBalancerHandler.on_present(m_handler, endpoints)
 
@@ -489,6 +490,9 @@ class TestLoadBalancerHandler(test_base.TestCase):
 
         lbaas_state = mock.sentinel.lbaas_state
         lbaas_state.service_pub_ip_info = None
+        loadbalancer = mock.Mock()
+        loadbalancer.port_id = 12345678
+        lbaas_state.loadbalancer = loadbalancer
         endpoints = mock.sentinel.endpoints
 
         floating_ip = {'floating_ip_address': '1.2.3.5',
@@ -509,6 +513,7 @@ class TestLoadBalancerHandler(test_base.TestCase):
         m_get_lbaas_state.return_value = lbaas_state
         m_handler._sync_lbaas_members = self._fake_sync_lbaas_members
         m_handler._drv_service_pub_ip = m_drv_service_pub_ip
+        m_handler._lb_provider = None
 
         h_lbaas.LoadBalancerHandler.on_present(m_handler, endpoints)
 
@@ -547,6 +552,7 @@ class TestLoadBalancerHandler(test_base.TestCase):
         m_set_lbaas_state.side_effect = (
             k_exc.K8sResourceNotFound('ep'))
         m_handler._drv_service_pub_ip = m_drv_service_pub_ip
+        m_handler._lb_provider = None
         h_lbaas.LoadBalancerHandler.on_present(m_handler, endpoints)
 
         m_get_lbaas_spec.assert_called_once_with(endpoints)


### PR DESCRIPTION
Upon kuryr-controller restart, if kuryr configuration regarding
octavia provider has changed, the cleanup process not only
removes the leftovers loadbalancers but also:
- remove the lbs with the previous octavia provider driver
- modifies endpoints annotations (provider information) to force
the recreation of the loadbalancer with the new provider

Change-Id: I78fd6bdd1f53ea8eb2ba85395fd2e3c651487c60