### PR TITLE
Bug 1847105: Fix hacking min version to 3.0.1

### DIFF
--- a/kuryr_kubernetes/controller/drivers/sriov.py
+++ b/kuryr_kubernetes/controller/drivers/sriov.py
@@ -133,7 +133,7 @@ class SriovVIFDriver(neutron_vif.NeutronPodVIFDriver):
                 amount_value = requests[sriov_resource_name]
                 total_amount += int(amount_value)
             except KeyError:
-                    continue
+                continue
 
         return total_amount
 
@@ -159,7 +159,7 @@ class SriovVIFDriver(neutron_vif.NeutronPodVIFDriver):
                 if driver in constants.USERSPACE_DRIVERS:
                     break
             except KeyError:
-                    continue
+                continue
 
     def _get_port_request(self, pod, project_id, subnets, security_groups):
         port_req_body = {

--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -349,7 +349,7 @@ def match_expressions(expressions, labels):
                 label_value = labels.get(str(exp['key']), None)
                 if exp_op == constants.K8S_OPERATOR_IN:
                     if label_value is None or label_value not in exp_values:
-                            return False
+                        return False
                 elif exp_op == constants.K8S_OPERATOR_NOT_IN:
                     if label_value in exp_values:
                         return False
@@ -373,7 +373,7 @@ def match_labels(crd_labels, labels):
     for crd_key, crd_value in crd_labels.items():
         label_value = labels.get(crd_key, None)
         if not label_value or crd_value != label_value:
-                return False
+            return False
     return True
 
 

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -319,7 +319,7 @@ def get_endpoints_link(service):
     link_parts = svc_link.split('/')
 
     if link_parts[-2] != 'services':
-        raise exceptions.IntegrityError(_(
+        raise exceptions.IntegrityError((
             "Unsupported service link: %(link)s") % {
             'link': svc_link})
     link_parts[-2] = 'endpoints'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
+hacking>=3.0.1,<3.1.0 # Apache-2.0
 
 coverage!=4.4,>=4.0 # Apache-2.0
 ddt>=1.0.1 # MIT


### PR DESCRIPTION
flake8 new release 3.8.0 added new checks and gate pep8
job start failing. hacking 3.0.1 fix the pinning of flake8 to
avoid bringing in a new version with new checks.

Though it is fixed in latest hacking but 2.0 and 3.0 has cap for
flake8 as <4.0.0 which mean flake8 new version 3.9.0 can also
break the pep8 job if new check are added.

To avoid similar gate break in future, we need to bump the hacking min
version.

- http://lists.openstack.org/pipermail/openstack-discuss/2020-May/014828.html

Change-Id: I54d3d778266d840bd724836018340d9bd3987844