### PR TITLE
Bug 1847011: Periodically fetch full list of watched resources 

### DIFF
--- a/kuryr_kubernetes/config.py
+++ b/kuryr_kubernetes/config.py
@@ -168,6 +168,14 @@ k8s_opts = [
                       'too high, Kuryr will take longer to reconnect when K8s '
                       'API stream was being silently broken.'),
                default=60),
+    cfg.IntOpt('watch_reconcile_period',
+               help=_('Period (in seconds) between iterations of fetching '
+                      'full list of watched K8s API resources and putting '
+                      'them into the enabled handlers. Setting 0 disables the '
+                      'periodic reconciling. The reconciliation is done to '
+                      'prevent Kuryr from missing events due to K8s API or '
+                      'etcd issues.'),
+               default=120),
     cfg.ListOpt('enabled_handlers',
                 help=_("The comma-separated handlers that should be "
                        "registered for watching in the pipeline."),

--- a/kuryr_kubernetes/handlers/base.py
+++ b/kuryr_kubernetes/handlers/base.py
@@ -20,7 +20,7 @@ class EventHandler(object, metaclass=abc.ABCMeta):
     """Base class for event handlers."""
 
     @abc.abstractmethod
-    def __call__(self, event):
+    def __call__(self, event, *args, **kwargs):
         """Handle the event."""
         raise NotImplementedError()
 

--- a/kuryr_kubernetes/handlers/dispatch.py
+++ b/kuryr_kubernetes/handlers/dispatch.py
@@ -51,7 +51,7 @@ class Dispatcher(h_base.EventHandler):
         handlers = key_group.setdefault(key, [])
         handlers.append(handler)
 
-    def __call__(self, event):
+    def __call__(self, event, *args, **kwargs):
         handlers = set()
 
         for key_fn, key_group in self._registry.items():
@@ -67,7 +67,7 @@ class Dispatcher(h_base.EventHandler):
                   obj_meta.get('uid'))
 
         for handler in handlers:
-            handler(event)
+            handler(event, *args, **kwargs)
 
 
 class EventConsumer(h_base.EventHandler, metaclass=abc.ABCMeta):
@@ -113,8 +113,8 @@ class EventPipeline(h_base.EventHandler, metaclass=abc.ABCMeta):
         for key_fn, key in consumer.consumes.items():
             self._dispatcher.register(key_fn, key, handler)
 
-    def __call__(self, event):
-        self._handler(event)
+    def __call__(self, event, *args, **kwargs):
+        self._handler(event, *args, **kwargs)
 
     @abc.abstractmethod
     def _wrap_dispatcher(self, dispatcher):

--- a/kuryr_kubernetes/handlers/k8s_base.py
+++ b/kuryr_kubernetes/handlers/k8s_base.py
@@ -73,7 +73,7 @@ class ResourceEventHandler(dispatch.EventConsumer, health.HealthHandler):
 
         return deletion_timestamp
 
-    def __call__(self, event):
+    def __call__(self, event, *args, **kwargs):
         event_type = event.get('type')
         obj = event.get('object')
         if 'MODIFIED' == event_type:

--- a/kuryr_kubernetes/handlers/logging.py
+++ b/kuryr_kubernetes/handlers/logging.py
@@ -32,8 +32,8 @@ class LogExceptions(base.EventHandler):
         self._handler = handler
         self._exceptions = exceptions
 
-    def __call__(self, event):
+    def __call__(self, event, *args, **kwargs):
         try:
-            self._handler(event)
+            self._handler(event, *args, **kwargs)
         except self._exceptions:
             LOG.exception("Failed to handle event %s", event)

--- a/kuryr_kubernetes/handlers/retry.py
+++ b/kuryr_kubernetes/handlers/retry.py
@@ -51,7 +51,7 @@ class Retry(base.EventHandler):
         self._interval = interval
         self._k8s = clients.get_kubernetes_client()
 
-    def __call__(self, event):
+    def __call__(self, event, *args, **kwargs):
         deadline = time.time() + self._timeout
         for attempt in itertools.count(1):
             if event.get('type') in ['MODIFIED', 'ADDED']:
@@ -75,7 +75,7 @@ class Retry(base.EventHandler):
                                       "object. Continuing with handler "
                                       "execution.")
             try:
-                self._handler(event)
+                self._handler(event, *args, **kwargs)
                 break
             except os_exc.ConflictException as ex:
                 if ex.details.startswith('Quota exceeded for resources'):

--- a/kuryr_kubernetes/tests/unit/test_watcher.py
+++ b/kuryr_kubernetes/tests/unit/test_watcher.py
@@ -179,13 +179,16 @@ class TestWatcher(test_base.TestCase):
         path = '/test'
         m_tg = mock.Mock()
         m_th = mock.Mock()
+        m_tt = mock.Mock()
         m_handler = mock.Mock()
         watcher_obj = watcher.Watcher(m_handler, m_tg)
         watcher_obj._idle[path] = True
         watcher_obj._watching[path] = m_th
+        watcher_obj._timers[path] = m_tt
 
         watcher_obj._stop_watch(path)
 
+        m_tt.stop.assert_called()
         m_th.stop.assert_called()
 
     def test_stop_watch_idle(self):

--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -73,8 +73,8 @@ oslo.policy==1.34.0
 oslo.privsep==1.28.0
 oslo.reports==1.18.0
 oslo.serialization==2.18.0
-oslo.service==1.24.0
-oslo.utils==3.33.0
+oslo.service==1.40.2
+oslo.utils==3.40.2
 oslo.versionedobjects==1.32.0
 oslotest==3.2.0
 packaging==17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ oslo.config>=6.1.0 # Apache-2.0
 oslo.log>=3.36.0 # Apache-2.0
 oslo.reports>=1.18.0 # Apache-2.0
 oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
-oslo.service!=1.28.1,>=1.24.0 # Apache-2.0
-oslo.utils>=3.33.0 # Apache-2.0
+oslo.service>=1.40.2 # Apache-2.0
+oslo.utils>=3.40.2 # Apache-2.0
 os-vif>=1.12.0 # Apache-2.0
 PrettyTable<0.8,>=0.7.2  # BSD
 pyroute2>=0.5.7;sys_platform!='win32' # Apache-2.0 (+ dual licensed GPL2)


### PR DESCRIPTION
Kuryr-Kubernetes relies on watching resources in K8s API using an HTTP
stream served by kube-apiserver. In such a distributed system this is
sometimes unstable and e.g. etcd issues can cause some events to be
omitted. To prevent controller from such situations this patch makes
sure that periodically a full list of resources is fetched and injected
as events into the handlers.

We should probably do the same for kuryr-daemon watcher, but that case
is less problematic as it'll be restarted in event of ADD requests
timing out.