### PR TITLE
Fix RPM spec pyroute2 version

### DIFF
--- a/openshift-kuryr-kubernetes-rhel8.spec
+++ b/openshift-kuryr-kubernetes-rhel8.spec
@@ -45,9 +45,9 @@ BuildRequires:  systemd-units
 
 Requires:       python3-%{project}-lib >= 0.5.0
 # NOTE(dulek): We should have pyroute2 0.5.7 here, but it's not avalable in
-# repos we have access to. Sticking with 0.5.3 should be fine as long as we
+# repos we have access to. Sticking with 0.5.6 should be fine as long as we
 # don't support SR-IOV stuff.
-Requires:       python3-pyroute2 >= 0.5.7
+Requires:       python3-pyroute2 >= 0.5.6
 Requires:       python3-requests >= 2.18.0
 Requires:       python3-eventlet >= 0.22.0
 Requires:       python3-oslo-cache >= 1.26.0


### PR DESCRIPTION
We don't have pyroute2 0.5.7 in OpenStack repos we use, we need to
downgrade the requirement to 0.5.6. The reason mistake got through the
CI is that dnf just installed older version of the Kuryr RPM that was in
the plashet and wasn't yet requiring pyroute2 that was not available.