### PR TITLE
Bug 1867520: Support upgrading LBaaSState annotation to KLB CRD

### DIFF
--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -317,7 +317,7 @@ def get_kuryrnetworkpolicy_crds(namespace=None):
         LOG.debug("Returning KuryrNetworkPolicies %s", knps)
     except k_exc.K8sResourceNotFound:
         LOG.exception("KuryrNetworkPolicy CRD not found")
-        raise
+        return []
     except k_exc.K8sClientException:
         LOG.exception("Kubernetes Client Exception")
         raise

--- a/kuryr_kubernetes/controller/handlers/loadbalancer.py
+++ b/kuryr_kubernetes/controller/handlers/loadbalancer.py
@@ -85,7 +85,7 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
             lb_ip = loadbalancer_crd['spec'].get('lb_ip')
             pub_info = loadbalancer_crd['status'].get(
                     'service_pub_ip_info')
-            if pub_info is None:
+            if pub_info is None and loadbalancer_crd['spec'].get('type'):
                 service_pub_ip_info = (
                     self._drv_service_pub_ip.acquire_service_pub_ip_info(
                         loadbalancer_crd['spec']['type'],
@@ -495,7 +495,7 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
         for l in loadbalancer_crd['status']['listeners']:
             if l['id'] != pool['listener_id']:
                 continue
-            for port in loadbalancer_crd['spec'].get('ports'):
+            for port in loadbalancer_crd['spec'].get('ports', []):
                 if l['port'] == port['port'] and l['protocol'] == port[
                         'protocol']:
                     return True

--- a/kuryr_kubernetes/k8s_client.py
+++ b/kuryr_kubernetes/k8s_client.py
@@ -177,14 +177,20 @@ class K8sClient(object):
         self._raise_from_response(response)
         return response.json().get('status')
 
+    def _jsonpatch_escape(self, value):
+        value = value.replace('~', '~0')
+        value = value.replace('/', '~1')
+        return value
+
     def remove_annotations(self, path, annotation_name):
+        LOG.debug("Remove annotations %(path)s: %(name)s",
+                  {'path': path, 'name': annotation_name})
         content_type = 'application/json-patch+json'
         url, header = self._get_url_and_header(path, content_type)
+        annotation_name = self._jsonpatch_escape(annotation_name)
 
         data = [{'op': 'remove',
-                 'path': '/metadata/annotations',
-                 'value': annotation_name}]
-
+                 'path': f'/metadata/annotations/{annotation_name}'}]
         response = self.session.patch(url, data=jsonutils.dumps(data),
                                       headers=header, cert=self.cert,
                                       verify=self.verify_server)

--- a/kuryr_kubernetes/objects/lbaas.py
+++ b/kuryr_kubernetes/objects/lbaas.py
@@ -147,3 +147,18 @@ class LBaaSServiceSpec(k_obj.KuryrK8sObjectBase):
         'type': obj_fields.StringField(nullable=True, default=None),
         'lb_ip': obj_fields.IPAddressField(nullable=True, default=None),
     }
+
+
+def flatten_object(ovo_primitive):
+    if type(ovo_primitive) is dict:
+        d = {}
+        for k, v in ovo_primitive['versioned_object.data'].items():
+            d[k] = flatten_object(v)
+        return d
+    elif type(ovo_primitive) is list:
+        ls = []
+        for v in ovo_primitive:
+            ls.append(flatten_object(v))
+        return ls
+    else:
+        return ovo_primitive

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -379,6 +379,18 @@ def get_endpoints_link(service):
     return "/".join(link_parts)
 
 
+def get_service_link(endpoints):
+    endpoints_link = endpoints['metadata']['selfLink']
+    link_parts = endpoints_link.split('/')
+
+    if link_parts[-2] != 'endpoints':
+        raise exceptions.IntegrityError(
+            f"Unsupported endpoints link: {endpoints_link}")
+    link_parts[-2] = 'services'
+
+    return "/".join(link_parts)
+
+
 def has_port_changes(service, loadbalancer_crd):
     if not loadbalancer_crd:
         return False


### PR DESCRIPTION
On upgrade from version using annotations on Endpoints and Services
objects to save information about created Octavia resources, to a
version where that information lives in KuryrLoadBalancer CRD we need to
make sure that data is converted. Otherwise we can end up with doubled
loadbalancers.

This commit makes sure data is converted before we try processing any
Service or Endpoints resource that has annotations.

Change-Id: I01ee5cedc7af8bd02283d065cd9b6f4a94f79888