### PR TITLE
Bug 1869294: Ignore ResourceNotReady from update_lbaas_sg() when handling network policy

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
@@ -215,7 +215,12 @@ class KuryrNetworkPolicyHandler(k8s_base.ResourceEventHandler):
                         self._is_service_affected(service, pods_to_update)):
                     continue
                 sgs = self._drv_svc_sg.get_security_groups(service, project_id)
-                self._drv_lbaas.update_lbaas_sg(service, sgs)
+                try:
+                    self._drv_lbaas.update_lbaas_sg(service, sgs)
+                except exceptions.ResourceNotReady:
+                    # We can ignore LB that's being created - its SGs will get
+                    # handled when members will be getting created.
+                    pass
 
         self._patch_kuryrnetworkpolicy_crd(knp, 'status',
                                            {'podSelector': current_sel})

--- a/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
@@ -300,7 +300,12 @@ class KuryrNetworkPolicyHandler(k8s_base.ResourceEventHandler):
                             self._is_service_affected(svc, pods_to_update)):
                         continue
                     sgs = self._drv_svc_sg.get_security_groups(svc, project_id)
-                    self._drv_lbaas.update_lbaas_sg(svc, sgs)
+                    try:
+                        self._drv_lbaas.update_lbaas_sg(svc, sgs)
+                    except exceptions.ResourceNotReady:
+                        # We can ignore LB that's being created - its SGs will
+                        # get handled when members will be getting created.
+                        pass
 
             self._drv_policy.delete_np_sg(crd_sg)
 


### PR DESCRIPTION
Currently for a pending Octavia LB being created, `update_lbaas_sg()` will raise `ResourceNotReady`, causing NetworkPolicy handling process to get postponed. There's no need to do that - once created the correct set of SGs will be determined by LB creation code itself, so there's no need to delay NP handling process. In slower environment this may even cause some NPs to be handled with massive delay.

This PR fixes that making sure we catch `ResourceNotReady` from `update_lbaas_sg()` in KuryrNetworkPolicyHandler and ignore it.