### PR TITLE
Bug 1867538: Move vifs to 'status' in the KuryrPort CRD.

### DIFF
--- a/kubernetes_crds/kuryr_crds/kuryrport.yaml
+++ b/kubernetes_crds/kuryr_crds/kuryrport.yaml
@@ -24,12 +24,16 @@ spec:
               required:
                 - podUid
                 - podNodeName
-                - vifs
               properties:
                 podUid:
                   type: string
                 podNodeName:
                   type: string
+            status:
+              type: object
+              required:
+                - vifs
+              properties:
                 vifs:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true

--- a/kuryr_kubernetes/cni/binding/dpdk.py
+++ b/kuryr_kubernetes/cni/binding/dpdk.py
@@ -163,7 +163,7 @@ class DpdkDriver(health.HealthHandler, b_base.BaseBindingDriver):
             vifs = {k: {'default': v['default'],
                         'vif': objects.base.VersionedObject
                         .obj_from_primitive(v['vif'])}
-                    for k, v in kp['spec']['vifs'].items()}
+                    for k, v in kp['status']['vifs'].items()}
         except (KeyError, AttributeError):
             LOG.exception(f"No vifs found on KuryrPort: {kp}")
             raise
@@ -177,12 +177,12 @@ class DpdkDriver(health.HealthHandler, b_base.BaseBindingDriver):
                          kp_link):
         k8s = clients.get_kubernetes_client()
         if vifs:
-            spec = {k: {'default': v['default'],
-                        'vif': v['vif'].obj_to_primitive()}
-                    for k, v in vifs.items()}
+            vif_dict = {k: {'default': v['default'],
+                            'vif': v['vif'].obj_to_primitive()}
+                        for k, v in vifs.items()}
 
-            LOG.info("Setting VIFs in KuryrPort %r", spec)
-            k8s.patch_crd('spec', kp_link, {'vifs': spec})
+            LOG.info("Setting VIFs in KuryrPort %r", vif_dict)
+            k8s.patch_crd('status', kp_link, {'vifs': vif_dict})
 
         if not labels:
             LOG.info("Removing Label annotation: %r", labels)

--- a/kuryr_kubernetes/cni/handlers.py
+++ b/kuryr_kubernetes/cni/handlers.py
@@ -23,7 +23,6 @@ from kuryr_kubernetes import constants as k_const
 from kuryr_kubernetes import exceptions as k_exc
 from kuryr_kubernetes.handlers import dispatch as k_dis
 from kuryr_kubernetes.handlers import k8s_base
-from kuryr_kubernetes import utils
 
 
 LOG = logging.getLogger(__name__)
@@ -70,7 +69,9 @@ class CNIHandlerBase(k8s_base.ResourceEventHandler, metaclass=abc.ABCMeta):
         except k_exc.K8sClientException:
             return {}
 
-        vifs_dict = utils.get_vifs_from_crd(kuryrport_crd)
+        vifs_dict = {k: obj_vif.base.VersionedObject
+                     .obj_from_primitive(v['vif'])
+                     for k, v in kuryrport_crd['status']['vifs'].items()}
         LOG.debug("Got vifs: %r", vifs_dict)
 
         return vifs_dict

--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -74,13 +74,13 @@ def get_vifs(pod):
     kp = get_kuryrport(pod)
     try:
         return {k: objects.base.VersionedObject.obj_from_primitive(v['vif'])
-                for k, v in kp['spec']['vifs'].items()}
+                for k, v in kp['status']['vifs'].items()}
     except (KeyError, AttributeError, TypeError):
         return {}
 
 
 def is_host_network(pod):
-    return pod['spec'].get('hostNetwork', False)
+    return pod['status'].get('hostNetwork', False)
 
 
 def get_pods(selector, namespace=None):
@@ -277,7 +277,7 @@ def create_security_group_rule_body(
 def get_pod_ip(pod):
     try:
         kp = get_kuryrport(pod)
-        vif = [x['vif'] for x in kp['spec']['vifs'].values()
+        vif = [x['vif'] for x in kp['status']['vifs'].values()
                if x['default']][0]
     except (KeyError, TypeError, IndexError):
         return None

--- a/kuryr_kubernetes/controller/handlers/kuryrport.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrport.py
@@ -61,7 +61,7 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
         self.k8s = clients.get_kubernetes_client()
 
     def on_present(self, kuryrport_crd):
-        if not kuryrport_crd['spec']['vifs']:
+        if not kuryrport_crd['status']['vifs']:
             # Get vifs
             if not self.get_vifs(kuryrport_crd):
                 # Ignore this event, according to one of the cases logged in
@@ -71,7 +71,7 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
         vifs = {ifname: {'default': data['default'],
                          'vif': objects.base.VersionedObject
                          .obj_from_primitive(data['vif'])}
-                for ifname, data in kuryrport_crd['spec']['vifs'].items()}
+                for ifname, data in kuryrport_crd['status']['vifs'].items()}
 
         if all([v['vif'].active for v in vifs.values()]):
             return
@@ -173,7 +173,7 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
             # properly released.
             security_groups = []
 
-        for data in kuryrport_crd['spec']['vifs'].values():
+        for data in kuryrport_crd['status']['vifs'].values():
             vif = objects.base.VersionedObject.obj_from_primitive(data['vif'])
             self._drv_vif_pool.release_vif(pod, vif, project_id,
                                            security_groups)
@@ -249,14 +249,14 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
 
     def _update_kuryrport_crd(self, kuryrport_crd, vifs):
         LOG.debug('Updatting CRD %s', kuryrport_crd["metadata"]["name"])
-        spec = {}
+        vif_dict = {}
         for ifname, data in vifs.items():
             data['vif'].obj_reset_changes(recursive=True)
-            spec[ifname] = {'default': data['default'],
-                            'vif': data['vif'].obj_to_primitive()}
+            vif_dict[ifname] = {'default': data['default'],
+                                'vif': data['vif'].obj_to_primitive()}
 
-        self.k8s.patch_crd('spec', kuryrport_crd['metadata']['selfLink'],
-                           {'vifs': spec})
+        self.k8s.patch_crd('status', kuryrport_crd['metadata']['selfLink'],
+                           {'vifs': vif_dict})
 
     def _is_network_policy_enabled(self):
         enabled_handlers = oslo_cfg.CONF.kubernetes.enabled_handlers

--- a/kuryr_kubernetes/controller/handlers/kuryrport.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrport.py
@@ -141,10 +141,6 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
             self.k8s.remove_finalizer(kuryrport_crd, constants.POD_FINALIZER)
             raise
 
-        if (driver_utils.is_host_network(pod) or
-                not pod['spec'].get('nodeName')):
-            return
-
         project_id = self._drv_project.get_project(pod)
         try:
             crd_pod_selectors = self._drv_sg.delete_sg_rules(pod)

--- a/kuryr_kubernetes/controller/handlers/pod_label.py
+++ b/kuryr_kubernetes/controller/handlers/pod_label.py
@@ -113,7 +113,7 @@ class PodLabelHandler(k8s_base.ResourceEventHandler):
     def _has_vifs(self, pod):
         try:
             kp = driver_utils.get_vifs(pod)
-            vifs = kp['spec']['vifs']
+            vifs = kp['status']['vifs']
             LOG.debug("Pod have associated KuryrPort with vifs: %s", vifs)
         except KeyError:
             return False

--- a/kuryr_kubernetes/controller/handlers/pod_label.py
+++ b/kuryr_kubernetes/controller/handlers/pod_label.py
@@ -52,12 +52,6 @@ class PodLabelHandler(k8s_base.ResourceEventHandler):
             # annotates the pod with the pod state.
             return
 
-        if (constants.K8S_ANNOTATION_VIF in
-                pod['metadata'].get('annotations', {})):
-            # NOTE(dulek): This might happen on upgrade, we need to wait for
-            #              annotation to be moved to KuryrPort CRD.
-            return
-
         current_pod_info = (pod['metadata'].get('labels'),
                             pod['status'].get('podIP'))
         previous_pod_info = self._get_pod_info(pod)

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -173,7 +173,9 @@ class VIFHandler(k8s_base.ResourceEventHandler):
             },
             'spec': {
                 'podUid': pod['metadata']['uid'],
-                'podNodeName': pod['spec']['nodeName'],
+                'podNodeName': pod['spec']['nodeName']
+            },
+            'status': {
                 'vifs': vifs
             }
         }

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrport.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrport.py
@@ -63,9 +63,9 @@ class TestKuryrPortHandler(test_base.TestCase):
             },
             'spec': {
                 'podUid': 'deadbeef',
-                'podNodeName': self._host,
-                'vifs': {}
-            }
+                'podNodeName': self._host
+            },
+            'status': {'vifs': {}}
         }
         self._vif1 = os_obj.vif.VIFBase()
         self._vif2 = os_obj.vif.VIFBase()
@@ -130,7 +130,7 @@ class TestKuryrPortHandler(test_base.TestCase):
                         update_crd, get_project):
         ged.return_value = [mock.MagicMock]
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
         get_project.return_value = self._project_id
 
         with mock.patch.object(kp, 'k8s') as k8s:
@@ -152,7 +152,7 @@ class TestKuryrPortHandler(test_base.TestCase):
         kp = kuryrport.KuryrPortHandler()
         self._vif1.active = True
         self._vif2.active = True
-        self._kp['spec']['vifs'] = {
+        self._kp['status']['vifs'] = {
             'eth0': {'default': True,
                      'vif': self._vif1.obj_to_primitive()},
             'eth1': {'default': False,
@@ -171,7 +171,7 @@ class TestKuryrPortHandler(test_base.TestCase):
                                        update_crd):
         ged.return_value = [self._driver]
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
         activate_vif.side_effect = os_exc.ResourceNotFound()
 
         kp.on_present(self._kp)
@@ -187,7 +187,7 @@ class TestKuryrPortHandler(test_base.TestCase):
     def test_on_present_pod_not_found(self, ged, get_k8s_client, activate_vif):
         ged.return_value = [self._driver]
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
 
         with mock.patch.object(kp, 'k8s') as k8s:
             k8s.get.side_effect = k_exc.K8sResourceNotFound(self._pod)
@@ -215,7 +215,7 @@ class TestKuryrPortHandler(test_base.TestCase):
                                         get_sg, release_vif):
         ged.return_value = [self._driver]
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
         update_crd.side_effect = k_exc.K8sResourceNotFound(self._kp)
         get_project.return_value = self._project_id
         get_sg.return_value = self._security_groups
@@ -246,7 +246,7 @@ class TestKuryrPortHandler(test_base.TestCase):
                                                     get_sg, release_vif):
         ged.return_value = [self._driver]
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
         update_crd.side_effect = k_exc.K8sClientException()
         get_project.return_value = self._project_id
         get_sg.return_value = self._security_groups
@@ -273,7 +273,7 @@ class TestKuryrPortHandler(test_base.TestCase):
         kp = kuryrport.KuryrPortHandler()
         self._vif2.plugin = constants.KURYR_VIF_TYPE_SRIOV
         self._vif2.active = True
-        self._kp['spec']['vifs'] = {
+        self._kp['status']['vifs'] = {
             'eth0': {'default': True,
                      'vif': self._vif2.obj_to_primitive()},
             'eth1': {'default': False,
@@ -313,7 +313,7 @@ class TestKuryrPortHandler(test_base.TestCase):
                            get_services, get_project):
         ged.return_value = [self._driver]
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
 
         with mock.patch.object(kp, 'k8s') as k8s:
             k8s.get.return_value = self._pod
@@ -333,7 +333,7 @@ class TestKuryrPortHandler(test_base.TestCase):
     def test_on_finalize_exception_on_pod(self, ged, k8s):
         ged.return_value = [self._driver]
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
 
         with mock.patch.object(kp, 'k8s') as k8s:
             k8s.get.side_effect = k_exc.K8sResourceNotFound(self._pod)
@@ -353,7 +353,7 @@ class TestKuryrPortHandler(test_base.TestCase):
                                                  is_host_network):
         ged.return_value = [self._driver]
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
         is_host_network.return_value = False
         _pod = dict(self._pod)
         del _pod['spec']['nodeName']
@@ -394,7 +394,7 @@ class TestKuryrPortHandler(test_base.TestCase):
                                            get_sg, release_vif):
         ged.return_value = [self._driver]
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
         is_host_network.return_value = False
         get_project.return_value = self._project_id
         delete_sg_rules.side_effect = k_exc.ResourceNotReady(self._pod)
@@ -447,7 +447,7 @@ class TestKuryrPortHandler(test_base.TestCase):
         self.addCleanup(CONF.clear_override, 'enforce_sg_rules',
                         group='octavia_defaults')
         kp = kuryrport.KuryrPortHandler()
-        self._kp['spec']['vifs'] = self._vifs_primitive
+        self._kp['status']['vifs'] = self._vifs_primitive
         is_host_network.return_value = False
         get_project.return_value = self._project_id
         selector = mock.sentinel.selector
@@ -686,10 +686,10 @@ class TestKuryrPortHandler(test_base.TestCase):
         vif2 = self._vif2.obj_to_primitive()
 
         kp.k8s.patch_crd.assert_called_once_with(
-            'spec', self._kp_link, {'vifs': {'eth0': {'default': True,
-                                                      'vif': vif1},
-                                             'eth1': {'default': False,
-                                                      'vif': vif2}}})
+            'status', self._kp_link, {'vifs': {'eth0': {'default': True,
+                                                        'vif': vif1},
+                                               'eth1': {'default': False,
+                                                        'vif': vif2}}})
 
     @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
     @mock.patch('kuryr_kubernetes.controller.drivers.base.MultiVIFDriver.'

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_vif.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_vif.py
@@ -65,8 +65,8 @@ class TestVIFHandler(test_base.TestCase):
                                  'namespace': self._pod_namespace,
                                  'labels': mock.ANY},
                     'spec': {'podUid': self._pod_uid,
-                             'podNodeName': 'hostname',
-                             'vifs': {}}}
+                             'podNodeName': 'hostname'},
+                    'status': {'vifs': {}}}
 
         self._handler = mock.MagicMock(spec=h_vif.VIFHandler)
         self._handler._drv_project = mock.Mock(spec=drivers.PodProjectDriver)

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_vif.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_vif.py
@@ -181,10 +181,9 @@ class TestVIFHandler(test_base.TestCase):
 
         h_vif.VIFHandler.on_present(self._handler, self._pod)
 
-        k8s.add_finalizer.assert_called_once_with(self._pod,
-                                                  k_const.POD_FINALIZER)
-        self._matc.assert_called_once_with(self._pod)
-        m_get_kuryrport.assert_called_once()
+        k8s.add_finalizer.assert_not_called()
+        self._matc.assert_not_called()
+        m_get_kuryrport.assert_not_called()
         self._request_vif.assert_not_called()
         self._request_additional_vifs.assert_not_called()
         self._activate_vif.assert_not_called()
@@ -192,8 +191,8 @@ class TestVIFHandler(test_base.TestCase):
     @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
     @mock.patch('kuryr_kubernetes.controller.drivers.utils.is_host_network')
     @mock.patch('kuryr_kubernetes.controller.drivers.utils.get_kuryrport')
-    def test_on_present_not_pending(self, m_get_kuryrport, m_host_network,
-                                    m_get_k8s_client):
+    def test_on_present_not_scheduled(self, m_get_kuryrport, m_host_network,
+                                      m_get_k8s_client):
         m_get_kuryrport.return_value = self._kp
         m_host_network.return_value = False
         self._is_pod_scheduled.return_value = False
@@ -203,10 +202,9 @@ class TestVIFHandler(test_base.TestCase):
 
         h_vif.VIFHandler.on_present(self._handler, self._pod)
 
-        k8s.add_finalizer.assert_called_once_with(self._pod,
-                                                  k_const.POD_FINALIZER)
-        self._matc.assert_called_once_with(self._pod)
-        m_get_kuryrport.assert_called_once()
+        k8s.add_finalizer.assert_not_called()
+        self._matc.assert_not_called()
+        m_get_kuryrport.assert_not_called()
         self._request_vif.assert_not_called()
         self._request_additional_vifs.assert_not_called()
         self._activate_vif.assert_not_called()
@@ -295,7 +293,7 @@ class TestVIFHandler(test_base.TestCase):
     def test_on_present_upgrade(self, m_get_kuryrport, m_host_network,
                                 m_get_k8s_client):
         m_get_kuryrport.return_value = self._kp
-        m_host_network.return_value = True
+        m_host_network.return_value = False
         self._matc.return_value = True
         k8s = mock.MagicMock()
         m_get_k8s_client.return_value = k8s

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -252,15 +252,6 @@ def extract_pod_annotation(annotation):
     return obj
 
 
-def get_vifs_from_crd(crd):
-    result = {}
-    for ifname in crd['spec']['vifs']:
-        result[ifname] = (objects.base.VersionedObject
-                          .obj_from_primitive(crd['spec']['vifs']
-                                              [ifname]['vif']))
-    return result
-
-
 def has_limit(quota):
     NO_LIMIT = -1
     return quota['limit'] != NO_LIMIT


### PR DESCRIPTION
In newly added CRD, KuryrPort, we noticed, that vifs key, which is now
under 'spec' object, is rather a thing which could be represented as the
CRD status.

In this patch we propose to move vifs data under the status key.
