### PR TITLE
Bug 1871058: NP: Don't add pods without IP to affectedPods

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -69,6 +69,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
         if 'remote_ip_prefixes' in rule:
             result['affectedPods'] = []
             for ip, namespace in rule['remote_ip_prefixes']:
+                if not ip:
+                    continue
                 result['affectedPods'].append({
                     'podIP': ip,
                     'podNamespace': namespace,

--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -269,7 +269,7 @@ def create_security_group_rule_body(
         security_group_rule_body['namespace'] = namespace
     if pods:
         security_group_rule_body['affectedPods'] = [
-            {'podIP': ip, 'podNamespace': ns} for ip, ns in pods.items()]
+            {'podIP': ip, 'podNamespace': ns} for ip, ns in pods.items() if ip]
     LOG.debug("Creating sg rule body %s", security_group_rule_body)
     return security_group_rule_body
 


### PR DESCRIPTION
We use affectedPods to comfortably track the list of the pods that the
NetworkPolicy indirectly targets (i.e. matches their ports). It doesn't
make sense to put pods without IP there, as well as it is impossible now
with new KuryrNetworkPolicy CRD.

We haven't seen that problem on previous CRD as we've used a weird
format to save that info: {'<pod-ip>': '<pod-namespace'}. If <pod-ip>
was None, json.dumps serialized that into {'null': '<pod-namespace>'},
which was as happily accepted by K8s API as it was utterly useless.

This commit makes sure we only put pods with IP on affectedPods field.
Please also note that we already have protection in place to make sure
we won't create rules for pods without IP (those rules would effectively
open too much traffic), so that is already covered.