### PR TITLE
Bug 1871839: Ensure Service is delete if lb CRD is already gone

### DIFF
--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -103,7 +103,10 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
 
         klb_crd_path = (f"{k_const.K8S_API_CRD_NAMESPACES}/"
                         f"{svc_namespace}/kuryrloadbalancers/{svc_name}")
-        k8s.delete(klb_crd_path)
+        try:
+            k8s.delete(klb_crd_path)
+        except k_exc.K8sResourceNotFound:
+            k8s.remove_finalizer(service, k_const.SERVICE_FINALIZER)
 
     def _has_clusterip(self, service):
         # ignore headless service, clusterIP is None


### PR DESCRIPTION
As the Finalizer is first removed from the lb CRD and
then from the Service, we should add protection for when
the CRD is gone but the Service is still present with
the Finalizer set.

Change-Id: I9fe88bb78fea4930c241ecf1117eafecaf279c94