### PR TITLE
Bug 1869606: Remove the pod interface even if VIF is gone

### DIFF
--- a/kuryr_kubernetes/cni/binding/base.py
+++ b/kuryr_kubernetes/cni/binding/base.py
@@ -168,3 +168,10 @@ def disconnect(vif, instance_info, ifname, netns=None, report_health=None,
         report_health(driver.is_alive())
     driver.disconnect(vif, ifname, netns, container_id)
     os_vif.unplug(vif, instance_info)
+
+
+def cleanup(ifname, netns):
+    with get_ipdb(netns) as c_ipdb:
+        if ifname in c_ipdb.interfaces:
+            with c_ipdb.interfaces[ifname] as iface:
+                iface.remove()


### PR DESCRIPTION
It seems that latest crio versions moved removal of network namespace to
later in the container lifecycle. This means that sometimes the network
namespace of a container will hang after pod is already gone from the
API and Kuryr assigned it's VIF to another pod. This might cause VLAN ID
conflicts, but normally that's not an issue as kuryr-daemon is removing
interfaces from container namespace on CNI DEL.

It may however happen that if kuryr-daemon was down when CNI DEL
happened, the info about the VIF saved in KuryrPort will already be
gone. In that case we simply returned success to the CNI without doing
any unplugging. Now if the netns is not removed immediately after that
we might end up with VLAN ID conflicts.

This commit makes sure that even if VIF info is gone, kuryr-daemon will
at least attempt to remove the container interface from the container
netns. This should limit the problem.