### PR TITLE
Bug 1872265: Remove right finalizer on pod absence.

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrport.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrport.py
@@ -135,11 +135,13 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
         try:
             pod = self.k8s.get(f"{constants.K8S_API_NAMESPACES}"
                                f"/{namespace}/pods/{name}")
-        except k_exc.K8sResourceNotFound as ex:
-            LOG.exception("Failed to get pod: %s", ex)
+        except k_exc.K8sResourceNotFound:
+            LOG.error("Pod %s/%s doesn't exists, deleting orphaned KuryrPort",
+                      namespace, name)
             # TODO(gryf): Free resources
-            self.k8s.remove_finalizer(kuryrport_crd, constants.POD_FINALIZER)
-            raise
+            self.k8s.remove_finalizer(kuryrport_crd,
+                                      constants.KURYRPORT_FINALIZER)
+            return
 
         project_id = self._drv_project.get_project(pod)
         try:

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrport.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrport.py
@@ -338,12 +338,11 @@ class TestKuryrPortHandler(test_base.TestCase):
         with mock.patch.object(kp, 'k8s') as k8s:
             k8s.get.side_effect = k_exc.K8sResourceNotFound(self._pod)
 
-            self.assertRaises(k_exc.K8sResourceNotFound, kp.on_finalize,
-                              self._kp)
+            self.assertIsNone(kp.on_finalize(self._kp))
 
             k8s.get.assert_called_once_with(self._pod_uri)
             k8s.remove_finalizer.assert_called_once_with(
-                self._kp, constants.POD_FINALIZER)
+                self._kp, constants.KURYRPORT_FINALIZER)
 
     @mock.patch('kuryr_kubernetes.controller.drivers.vif_pool.MultiVIFPool.'
                 'release_vif')


### PR DESCRIPTION
In case of missing pod, KuryrPort should remove itself by removing its
finalizer, not non-existent pod finalizer.

Closes-Bug: 1892863
Change-Id: I10fc315b6ff456282d71d84e6cee4c226ac5cdba
(cherry picked from commit c7fd31951b6a3121b95c81078522ad57790ad8b5)