### PR TITLE
Bug 1872265: Guard against manually removing of KuryrPort CRD.

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrport.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrport.py
@@ -143,6 +143,15 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
                                       constants.KURYRPORT_FINALIZER)
             return
 
+        if 'deletionTimestamp' not in pod['metadata']:
+            # NOTE(gryf): Ignore deleting KuryrPort, since most likely it was
+            # removed manually, while we need vifs for corresponding pod
+            # object which apperantely is still running.
+            LOG.warning('Manually triggered KuryrPort %s removal. This '
+                        'action should be avoided, since KuryrPort CRDs are '
+                        'internal to Kuryr.', name)
+            return
+
         project_id = self._drv_project.get_project(pod)
         try:
             crd_pod_selectors = self._drv_sg.delete_sg_rules(pod)


### PR DESCRIPTION
It might happen, that operator would manually removing KuryrPort CRD
corresponding to the pod, and than pod would become broken  - there
would be no connectivity to it.

In this patch we prevent from removing KP, in case Pod is not in
deleting state. Now, it will defer the deletion till the Pod deletion.

Change-Id: Idd6383296723c41ed6f29715969c452ef3fcdb1f
(cherry picked from commit 98c78b75bb43c093039187612af05858c139a3b8)