### PR TITLE
Bug 1874439: Ignore CRD creation errors when ns is terminated

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -52,7 +52,14 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
 
         knp = self._get_knp_crd(policy)
         if not knp:
-            self._create_knp_crd(policy, i_rules, e_rules)
+            try:
+                self._create_knp_crd(policy, i_rules, e_rules)
+            except exceptions.K8sNamespaceTerminating:
+                LOG.warning('Namespace %s is being terminated, ignoring '
+                            'NetworkPolicy %s in that namespace.',
+                            policy['metadata']['namespace'],
+                            policy['metadata']['name'])
+                return
         else:
             self._patch_knp_crd(policy, i_rules, e_rules, knp)
 

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -97,6 +97,10 @@ class VIFHandler(k8s_base.ResourceEventHandler):
             except k_exc.K8sNamespaceTerminating:
                 # The underlying namespace is being terminated, we can
                 # ignore this and let `on_finalize` handle this now.
+                LOG.warning('Namespace %s is being terminated, ignoring Pod '
+                            '%s in that namespace.',
+                            pod['metadata']['namespace'],
+                            pod['metadata']['name'])
                 return
             except k_exc.K8sClientException as ex:
                 LOG.exception("Kubernetes Client Exception creating "


### PR DESCRIPTION
There is a delay between namespace termination and having all the
objects from that namespace marked as being terminated. This means that
if on CRD creation we'll get a response stating that the namespace is
being terminated - we should ignore it, not fail. This commit makes sure
we only log a warning for those errors.