### PR TITLE
Bug 1873449: Delete ports without device_owner on ns deletion

### DIFF
--- a/kuryr_kubernetes/controller/drivers/namespace_subnet.py
+++ b/kuryr_kubernetes/controller/drivers/namespace_subnet.py
@@ -106,7 +106,9 @@ class NamespacePodSubnetDriver(default_subnet.DefaultPodSubnetDriver):
                           "Deleting leftovers ports before retrying", net_id)
             leftover_ports = os_net.ports(network_id=net_id)
             for leftover_port in leftover_ports:
-                if leftover_port.device_owner not in ['trunk:subport',
+                # NOTE(dulek): '' is there because Neutron seems to unset
+                #              device_owner on detach.
+                if leftover_port.device_owner not in ['', 'trunk:subport',
                                                       kl_const.DEVICE_OWNER]:
                     continue
                 try:


### PR DESCRIPTION
Neutron clears device_owner when port is detached. This means that with
pools we need to consider ports without device_owner set when doing
cleanup on namespace deletion.