### PR TITLE
Bug 1867534: Catch exceptions for deleted pod.

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrport.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrport.py
@@ -139,8 +139,13 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
             LOG.error("Pod %s/%s doesn't exists, deleting orphaned KuryrPort",
                       namespace, name)
             # TODO(gryf): Free resources
-            self.k8s.remove_finalizer(kuryrport_crd,
-                                      constants.KURYRPORT_FINALIZER)
+            try:
+                self.k8s.remove_finalizer(kuryrport_crd,
+                                          constants.KURYRPORT_FINALIZER)
+            except k_exc.K8sClientException as ex:
+                LOG.exception("Failed to remove finalizer from KuryrPort %s",
+                              ex)
+                raise
             return
 
         if 'deletionTimestamp' not in pod['metadata']:

--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -56,7 +56,8 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
         k8s = clients.get_kubernetes_client()
         loadbalancer_crd = k8s.get_loadbalancer_crd(service)
         try:
-            self._patch_service_finalizer(service)
+            if not self._patch_service_finalizer(service):
+                return
         except k_exc.K8sClientException as ex:
             LOG.exception("Failed to set service finalizer: %s", ex)
             raise
@@ -93,7 +94,7 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
 
     def _patch_service_finalizer(self, service):
         k8s = clients.get_kubernetes_client()
-        k8s.add_finalizer(service, k_const.SERVICE_FINALIZER)
+        return k8s.add_finalizer(service, k_const.SERVICE_FINALIZER)
 
     def on_finalize(self, service):
         k8s = clients.get_kubernetes_client()

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -75,7 +75,15 @@ class VIFHandler(k8s_base.ResourceEventHandler):
         # subsequent updates of the pod, add_finalizer will ignore this if
         # finalizer exists.
         k8s = clients.get_kubernetes_client()
-        k8s.add_finalizer(pod, constants.POD_FINALIZER)
+
+        try:
+            if not k8s.add_finalizer(pod, constants.POD_FINALIZER):
+                # NOTE(gryf) It might happen that pod will be deleted even
+                # before we got here.
+                return
+        except k_exc.K8sClientException as ex:
+            LOG.exception("Failed to add finalizer to pod object: %s", ex)
+            raise
 
         if self._move_annotations_to_crd(pod):
             return
@@ -110,7 +118,11 @@ class VIFHandler(k8s_base.ResourceEventHandler):
             kp = k8s.get(KURYRPORT_URI.format(ns=pod["metadata"]["namespace"],
                                               crd=pod["metadata"]["name"]))
         except k_exc.K8sResourceNotFound:
-            k8s.remove_finalizer(pod, constants.POD_FINALIZER)
+            try:
+                k8s.remove_finalizer(pod, constants.POD_FINALIZER)
+            except k_exc.K8sClientException as ex:
+                LOG.exception('Failed to remove finalizer from pod: %s', ex)
+                raise
             return
 
         if 'deletionTimestamp' in kp['metadata']:


### PR DESCRIPTION
It might happen, that during adding and instantly removing pod, vif
handler will not be able to set the finalizer for such object, resulting
in error. In this patch we prevent for such case.

Closes-Bug: 1894212
Change-Id: I5b3b4b36ae0c2fca7c16153f75c62607efbc3ce4
(cherry picked from commit f2e3ffb585a8c98f6994373dc66cac1c549ae659)