### PR TITLE
Bug 1875491:Clean lb crd status upon Load Balancer removal

### DIFF
--- a/kuryr_kubernetes/exceptions.py
+++ b/kuryr_kubernetes/exceptions.py
@@ -52,6 +52,12 @@ class K8sNamespaceTerminating(K8sForbidden):
             "Namespace already terminated: %r" % message)
 
 
+class K8sUnprocessableEntity(K8sClientException):
+    def __init__(self, message):
+        super(K8sUnprocessableEntity, self).__init__(
+            "Unprocessable: %r" % message)
+
+
 class InvalidKuryrNetworkAnnotation(Exception):
     pass
 

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
@@ -526,7 +526,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
         loadbalancer = {
-            'name': 'TEST_NAME',
+            'name': 'test_namespace/test_name',
             'project_id': 'TEST_PROJECT',
             'subnet_id': 'D3FA400A-F543-4B91-9CD3-047AF0CE42D1',
             'ip': '1.2.3.4',

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -423,3 +423,18 @@ def get_service_subnet_version():
         LOG.exception("Service subnet %s not found", svc_subnet_id)
         raise
     return svc_subnet.ip_version
+
+
+def clean_lb_crd_status(loadbalancer_name):
+    namespace, name = loadbalancer_name.split('/')
+    k8s = clients.get_kubernetes_client()
+    try:
+        k8s.patch_crd('status', f'{constants.K8S_API_CRD_NAMESPACES}'
+                      f'/{namespace}/kuryrloadbalancers/{name}', {})
+    except exceptions.K8sResourceNotFound:
+        LOG.debug('KuryrLoadbalancer CRD not found %s',
+                  name)
+    except exceptions.K8sClientException:
+        LOG.exception('Error updating KuryrLoadbalancer CRD %s',
+                      name)
+        raise


### PR DESCRIPTION
When a lb transitions to ERROR or the IP on the Service
spec differs from the lb VIP, the lb is released and
the CRD doesn't get updated, causing Not Found expections
when handling the creation of others load balancer
resources. This commit fixes the issue by ensuring the
clean up of the status field happens upon lb release.
Also, it adds protection in case we still get
nonexistent lb on the CRD.

Closes-Bug: 1894758
Change-Id: I484ece6a7b52b51d878f724bd4fad0494eb759d6