### PR TITLE
Bug 1876566: Leaks of loadbalancer

### DIFF
--- a/kubernetes_crds/kuryr_crds/kuryrloadbalancer.yaml
+++ b/kubernetes_crds/kuryr_crds/kuryrloadbalancer.yaml
@@ -108,6 +108,8 @@ spec:
                 type: string
               type:
                 type: string
+              provider:
+                type: string
           status:
             type: object
             properties:

--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -47,6 +47,7 @@ _OCTAVIA_TAGGING_VERSION = 2, 5
 # In order to make it simpler, we assume this is supported only from 2.13
 _OCTAVIA_DL_VERSION = 2, 13
 _OCTAVIA_ACL_VERSION = 2, 12
+_OCTAVIA_PROVIDER_VERSION = 2, 6
 
 
 class LBaaSv2Driver(base.LBaaSDriver):
@@ -58,6 +59,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
         self._octavia_tags = False
         self._octavia_acls = False
         self._octavia_double_listeners = False
+        self._octavia_providers = False
         # Check if Octavia API supports tagging.
         # TODO(dulek): *Maybe* this can be replaced with
         #         lbaas.get_api_major_version(version=_OCTAVIA_TAGGING_VERSION)
@@ -80,9 +82,14 @@ class LBaaSv2Driver(base.LBaaSDriver):
                         'API %s does not support resource tagging. Kuryr '
                         'will put requested tags in the description field of '
                         'Octavia resources.', v_str)
+        if v >= _OCTAVIA_PROVIDER_VERSION:
+            self._octavia_providers = True
 
     def double_listeners_supported(self):
         return self._octavia_double_listeners
+
+    def providers_supported(self):
+        return self._octavia_providers
 
     def get_octavia_version(self):
         lbaas = clients.get_loadbalancer_client()

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_loadbalancer.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_loadbalancer.py
@@ -79,7 +79,8 @@ def get_lb_crd():
                         ]
                     }
                 ],
-                "type": "LoadBalancer"
+                "type": "LoadBalancer",
+                "provider": "ovn"
                 },
             "status": {
                 "listeners": [
@@ -213,14 +214,12 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
         m_get_drv_service_pub_ip.return_value = mock.sentinel.drv_lb_ip
         m_get_svc_drv_project.return_value = mock.sentinel.drv_svc_project
         m_get_svc_sg_drv.return_value = mock.sentinel.drv_sg
-        m_cfg.kubernetes.endpoints_driver_octavia_provider = 'default'
         handler = h_lb.KuryrLoadBalancerHandler()
 
         self.assertEqual(mock.sentinel.drv_lbaas, handler._drv_lbaas)
         self.assertEqual(mock.sentinel.drv_project, handler._drv_pod_project)
         self.assertEqual(mock.sentinel.drv_subnets, handler._drv_pod_subnets)
         self.assertEqual(mock.sentinel.drv_lb_ip, handler._drv_service_pub_ip)
-        self.assertIsNone(handler._lb_provider)
 
     @mock.patch('kuryr_kubernetes.controller.drivers.base.'
                 'ServiceProjectDriver.get_instance')
@@ -245,14 +244,12 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
         m_get_drv_service_pub_ip.return_value = mock.sentinel.drv_lb_ip
         m_get_svc_drv_project.return_value = mock.sentinel.drv_svc_project
         m_get_svc_sg_drv.return_value = mock.sentinel.drv_sg
-        m_cfg.kubernetes.endpoints_driver_octavia_provider = 'ovn'
         handler = h_lb .KuryrLoadBalancerHandler()
 
         self.assertEqual(mock.sentinel.drv_lbaas, handler._drv_lbaas)
         self.assertEqual(mock.sentinel.drv_project, handler._drv_pod_project)
         self.assertEqual(mock.sentinel.drv_subnets, handler._drv_pod_subnets)
         self.assertEqual(mock.sentinel.drv_lb_ip, handler._drv_service_pub_ip)
-        self.assertEqual('ovn', handler._lb_provider)
 
     def test_on_present(self):
         m_drv_service_pub_ip = mock.Mock()


### PR DESCRIPTION
In theory with the usage of Finalizers having leaks of loadbalancers
is not possible anymore, and if the CRD is deleted it gets recreated
and also the loadbalancer is recreated.

This commit is deleting _cleanup_leftover_lbaas function and adapting
the code to recreate loadbalancers if the provider does not match.

Change-Id: I0db62a845b23a32eef4358368332c4da2cad5460