### PR TITLE
Bug 1867534: Added new K8sFieldValueForbidden exception

### DIFF
--- a/kuryr_kubernetes/exceptions.py
+++ b/kuryr_kubernetes/exceptions.py
@@ -58,6 +58,10 @@ class K8sUnprocessableEntity(K8sClientException):
             "Unprocessable: %r" % message)
 
 
+class K8sFieldValueForbidden(K8sUnprocessableEntity):
+    pass
+
+
 class InvalidKuryrNetworkAnnotation(Exception):
     pass
 


### PR DESCRIPTION
During tests it turns out, that we didn't catch Forbidden exceptions,
since there was no forbidden http code sent from kubernetes API. In this
Patch we introduce new exception K8sFieldValueForbidden, which will be
raised on 422 Unprocessable Entity, k8s API returns.

Also, taken care of objects in state terminating in remove_finalizer
method.

Closes-Bug: 1895124
Change-Id: If4ac93190db3a56ee6b94ca122bfd2e95c29ffb9