### PR TITLE
Bug 1878725: Add iptables wrappers to Kuryr CNI

### DIFF
--- a/images/iptables-scripts/ip6tables
+++ b/images/iptables-scripts/ip6tables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /sbin/ip6tables "$@"

--- a/images/iptables-scripts/iptables
+++ b/images/iptables-scripts/iptables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /sbin/iptables "$@"

--- a/openshift-kuryr-cni-rhel8.Dockerfile
+++ b/openshift-kuryr-cni-rhel8.Dockerfile
@@ -11,6 +11,9 @@ ARG OSLO_LOCK_PATH=/var/kuryr-lock
 
 COPY --from=builder /go/bin/kuryr-cni /kuryr-cni
 
+COPY ./images/iptables-scripts/iptables /usr/sbin/
+COPY ./images/iptables-scripts/ip6tables /usr/sbin/
+
 # FIXME(dulek): For some reason the local repo in OKD builds is disabled,
 #               using sed to enable it. Ignoring fail as it won't work (nor
 #               it's necessary) in OCP builds.


### PR DESCRIPTION
This commit ensures iptables commands are
available on the containers, by relying on
the iptables utility installed on the host.