### PR TITLE
Bug 1879855: Fix inability to determine Octavia version.

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -95,10 +95,11 @@ class LBaaSv2Driver(base.LBaaSDriver):
         return self._octavia_double_listeners
 
     def get_octavia_version(self):
-        lbaas = clients.get_loadbalancer_client()
+        sdk = clients.get_openstacksdk()
         region_name = getattr(CONF.neutron, 'region_name', None)
 
-        regions = lbaas.get_all_version_data()
+        regions = sdk.config.get_session().get_all_version_data(
+            service_type='load-balancer')
         # If region was specified take it, otherwise just take first as default
         endpoints = regions.get(region_name, list(regions.values())[0])
         # Take the first endpoint

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
@@ -105,9 +105,16 @@ class TestLBaaSv2Driver(test_base.TestCase):
             self.assertEqual({}, req, 'Unnecessary description added to '
                                       'resource %s' % res)
 
-    def test_get_octavia_version(self):
-        lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
-        lbaas.get_all_version_data.return_value = OCTAVIA_VERSIONS
+    @mock.patch('kuryr_kubernetes.clients.get_openstacksdk')
+    def test_get_octavia_version(self, get_os_sdk):
+        get_all_version_data = mock.Mock()
+        get_all_version_data.return_value = OCTAVIA_VERSIONS
+        session = mock.Mock()
+        session.get_all_version_data = get_all_version_data
+        os_sdk = mock.Mock()
+        os_sdk.config.get_session.return_value = session
+        get_os_sdk.return_value = os_sdk
+
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
         self.assertEqual((2, 2),
                          d_lbaasv2.LBaaSv2Driver.get_octavia_version(m_driver))


### PR DESCRIPTION
In OpenStackSDK, starting from version 0.18, there is a method available
for getting list for specified OpenStack service. In our case it is a
load balancer. In 3.11 however, we only have version 0.17 available
without that method causing container with kuryr-controller in
crashloop. This commit is fixing this in favor of directly looking at
Keystone catalogue.