### PR TITLE
Bug 1860030: Civilize logging vol 2

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -676,6 +676,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 constants.K8S_API_CRD_NAMESPACES,
                 namespace)
             netpolicy_crd = self.kubernetes.post(url, netpolicy_crd)
+        except exceptions.K8sNamespaceTerminating:
+            raise
         except exceptions.K8sClientException:
             LOG.exception("Kubernetes Client Exception creating "
                           "KuryrNetworkPolicy CRD.")

--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -160,10 +160,10 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
                 loadbalancer_crd)
         except k_exc.K8sConflict:
             raise k_exc.ResourceNotReady(svc_name)
+        except k_exc.K8sNamespaceTerminating:
+            raise
         except k_exc.K8sClientException:
-            LOG.exception("Kubernetes Client Exception creating "
-                          "kuryrloadbalancer CRD. %s"
-                          % k_exc.K8sClientException)
+            LOG.exception("Exception when creating KuryrLoadBalancer CRD.")
             raise
         return loadbalancer_crd
 
@@ -359,10 +359,10 @@ class EndpointsHandler(k8s_base.ResourceEventHandler):
                 k_const.K8S_API_CRD_NAMESPACES, namespace), loadbalancer_crd)
         except k_exc.K8sConflict:
             raise k_exc.ResourceNotReady(loadbalancer_crd)
+        except k_exc.K8sNamespaceTerminating:
+            raise
         except k_exc.K8sClientException:
-            LOG.exception("Kubernetes Client Exception creating "
-                          "kuryrloadbalancer CRD. %s" %
-                          k_exc.K8sClientException)
+            LOG.exception("Exception when creating KuryrLoadBalancer CRD.")
             raise
 
     def _update_crd_spec(self, loadbalancer_crd, endpoints):

--- a/kuryr_kubernetes/exceptions.py
+++ b/kuryr_kubernetes/exceptions.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from kuryr_kubernetes import utils
+
 
 class K8sClientException(Exception):
     pass
@@ -24,8 +26,16 @@ class IntegrityError(RuntimeError):
 
 class ResourceNotReady(Exception):
     def __init__(self, resource):
-        super(ResourceNotReady, self).__init__("Resource not ready: %r"
-                                               % resource)
+        msg = resource
+        if type(resource) == dict:
+            if resource.get('metadata', {}).get('name', None):
+                res_name = utils.get_res_unique_name(resource)
+                kind = resource.get('kind')
+                if kind:
+                    msg = f'{kind} {res_name}'
+                else:
+                    msg = res_name
+        super(ResourceNotReady, self).__init__("Resource not ready: %r" % msg)
 
 
 class K8sResourceNotFound(K8sClientException):

--- a/kuryr_kubernetes/handlers/retry.py
+++ b/kuryr_kubernetes/handlers/retry.py
@@ -16,6 +16,8 @@
 import itertools
 import time
 
+import requests
+
 from openstack import exceptions as os_exc
 from oslo_log import log as logging
 from oslo_utils import excutils
@@ -70,7 +72,8 @@ class Retry(base.EventHandler):
                                       "retry as the object %s has already "
                                       "been deleted.", obj_link)
                             return
-                        except exceptions.K8sClientException:
+                        except (exceptions.K8sClientException,
+                                requests.ConnectionError):
                             LOG.debug("Kubernetes client error getting the "
                                       "object. Continuing with handler "
                                       "execution.")

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
@@ -200,6 +200,27 @@ class BaseVIFPool(test_base.TestCase):
                           tuple(security_groups))
         m_driver._drv_vif.request_vifs.assert_not_called()
 
+    @ddt.data((neutron_vif.NeutronPodVIFDriver),
+              (nested_vlan_vif.NestedVlanPodVIFDriver))
+    def test__populate_pool_not_ready_dont_raise(self, m_vif_driver):
+        cls = vif_pool.BaseVIFPool
+        m_driver = mock.MagicMock(spec=cls)
+
+        cls_vif_driver = m_vif_driver
+        vif_driver = mock.MagicMock(spec=cls_vif_driver)
+        m_driver._drv_vif = vif_driver
+
+        pod = mock.sentinel.pod
+        project_id = str(uuid.uuid4())
+        subnets = mock.sentinel.subnets
+        security_groups = 'test-sg'
+        pool_key = (mock.sentinel.host_addr, project_id)
+        m_driver._recovered_pools = False
+
+        cls._populate_pool(m_driver, pool_key, pod, subnets,
+                           tuple(security_groups), raise_not_ready=False)
+        m_driver._drv_vif.request_vifs.assert_not_called()
+
     @mock.patch('time.time', return_value=0)
     def test__populate_pool_no_update(self, m_time):
         cls = vif_pool.BaseVIFPool

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -101,11 +101,14 @@ def get_res_unique_name(resource):
     """Returns a unique name for the resource like pod or CRD.
 
     It returns a unique name for the resource composed of its name and the
-    namespace it is running on.
+    namespace it is created in or just name for cluster-scoped resources.
 
-    :returns: String with namespace/name of the resource
+    :returns: String with <namespace/>name of the resource
     """
-    return "%(namespace)s/%(name)s" % resource['metadata']
+    try:
+        return "%(namespace)s/%(name)s" % resource['metadata']
+    except KeyError:
+        return "%(name)s" % resource['metadata']
 
 
 def check_suitable_multi_pool_driver_opt(pool_driver, pod_driver):


### PR DESCRIPTION
This is another attempt at getting the useless tracebacks out of logs
for any level higher than debug. In particular:

* All pools logs regarding "Kuryr-controller not yet ready to *" are now
  on debug level.
* The ugly ResourceNotReady raised from _populate_pool is now suppressed
  if method is run from eventlet.spawn(), which prevents that exception
  being logged by eventlet.
* ResourceNotReady will only print namespace/name or name, not the full
  resource representation.
* ConnectionResetError is suppressed on Retry handler level just as any
  other K8sClientError.