### PR TITLE
Bug 1881931: Skip KuryrLoadbalancer creation for Headless Service

### DIFF
--- a/kuryr_kubernetes/constants.py
+++ b/kuryr_kubernetes/constants.py
@@ -69,6 +69,8 @@ K8S_ANNOTATION_OLD_DRIVER = 'old_driver'
 K8S_ANNOTATION_CURRENT_DRIVER = 'current_driver'
 K8S_ANNOTATION_NEUTRON_PORT = 'neutron_id'
 
+K8S_ANNOTATION_HEADLESS_SERVICE = 'service.kubernetes.io/headless'
+
 POD_FINALIZER = KURYR_FQDN + '/pod-finalizer'
 KURYRNETWORK_FINALIZER = 'kuryrnetwork.finalizers.kuryr.openstack.org'
 KURYRLB_FINALIZER = 'kuryr.openstack.org/kuryrloadbalancer-finalizers'

--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -272,7 +272,9 @@ class EndpointsHandler(k8s_base.ResourceEventHandler):
         k8s = clients.get_kubernetes_client()
         loadbalancer_crd = k8s.get_loadbalancer_crd(endpoints)
 
-        if not self._has_pods(endpoints):
+        if (not self._has_pods(endpoints) or
+                k_const.K8S_ANNOTATION_HEADLESS_SERVICE
+                in endpoints['metadata'].get('labels', [])):
             LOG.debug("Ignoring Kubernetes endpoints %s",
                       endpoints['metadata']['name'])
             return


### PR DESCRIPTION
Headless Service are not wired by Kuryr as it returns
directly the Pod's IPs behind the Service and do not
load-balance between them. This commit makes sure a klb
CR is not created for headless services as a LB won't
get created for it.

Change-Id: Ib389ddd5edca44c713149adc13486ab0b08007d2