### PR TITLE
Bug 1883167: Avoid race when pod is deleted before finalizer is added

### DIFF
--- a/kuryr_kubernetes/k8s_client.py
+++ b/kuryr_kubernetes/k8s_client.py
@@ -271,7 +271,11 @@ class K8sClient(object):
                 # Object is being deleting or gone. Return.
                 return False
             except exc.K8sConflict:
-                obj = self.get(path)
+                try:
+                    obj = self.get(path)
+                except exc.K8sResourceNotFound:
+                    # Object got removed before finalizer was set
+                    return False
                 if finalizer in obj['metadata'].get('finalizers', []):
                     # Finalizer is there, return.
                     return True


### PR DESCRIPTION
It may be possible that add_finalizer function first fails due
to a Conflict updating the object as it got updated (in this case
triggered the deletion) from the Kubernetes side, and then when
trying to get the new object this is actually gone as the deletion
was completed in between both actions. If that is the case we just
need to return false as there is no need to add a finalizer for it

Change-Id: I118a7c01d98722af30435f4d091820c81e4e95e4