### PR TITLE
Bug 1883832: Ensure klb handler reacretes lb

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -376,7 +376,10 @@ class LBaaSv2Driver(base.LBaaSDriver):
         # when enforcing sg rules on the lb sg, meaning octavia
         # Amphora provider is configured.
         if CONF.octavia_defaults.enforce_sg_rules:
-            sg_id = self._get_vip_port(loadbalancer).security_group_ids[0]
+            try:
+                sg_id = self._get_vip_port(loadbalancer).security_group_ids[0]
+            except AttributeError:
+                sg_id = None
             if sg_id:
                 rules = os_net.security_group_rules(security_group_id=sg_id,
                                                     description=listener[


### PR DESCRIPTION
When user manually deletes the load balancer for one specific service
we need to recreate the load balanacer.

This commit makes sure that the load balancer is recreated when the
service is updated.

Change-Id: I47cf26bf50bba865d727221c8df09bce01a9935a