### PR TITLE
Bug 1883565: Skip update of vip sg if lb is gone

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -356,11 +356,12 @@ class LBaaSv2Driver(base.LBaaSDriver):
         # NOTE(maysams): When ovn-octavia provider is used
         # there is no need to set a security group for
         # the load balancer as it wouldn't be enforced.
-        if not CONF.octavia_defaults.enforce_sg_rules:
+        if not CONF.octavia_defaults.enforce_sg_rules and result:
             os_net = clients.get_network_client()
             vip_port = self._get_vip_port(loadbalancer)
-            os_net.update_port(vip_port.id, security_groups=[])
-            loadbalancer['security_groups'] = []
+            if vip_port:
+                os_net.update_port(vip_port.id, security_groups=[])
+                loadbalancer['security_groups'] = []
 
         return result
 


### PR DESCRIPTION
It's possible that while ensuring the listener,
the load balancer was not present anymore and
consequently there is not need to update the vip
port sg. This commit enforces that the update only
happens if a listener was created and the vip is
present.

Change-Id: I3f104062887626f7b374993b5466fc962ccca85a