### PR TITLE
Updating kuryr-cni builder & base images to be consistent with ART

### DIFF
--- a/openshift-kuryr-cni-rhel8.Dockerfile
+++ b/openshift-kuryr-cni-rhel8.Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.7 AS builder
 
 WORKDIR /go/src/github.com/openshift/kuryr-kubernetes
 COPY . .
 RUN go build -o /go/bin/kuryr-cni ./kuryr_cni
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
 
 ENV container=oci
 ARG OSLO_LOCK_PATH=/var/kuryr-lock


### PR DESCRIPTION
Updating kuryr-cni builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/0b997d0add07947c7ca65baa44901a2d113fd0e9/images/kuryr-cni.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
