### PR TITLE
Updating kuryr-controller builder & base images to be consistent with ART

### DIFF
--- a/openshift-kuryr-controller-rhel8.Dockerfile
+++ b/openshift-kuryr-controller-rhel8.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
 
 ENV container=oci
 


### PR DESCRIPTION
Updating kuryr-controller builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/ac81dd4ff0bd57c4e75058d25b40615b92948259/images/kuryr-controller.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
