### PR TITLE
Updating kuryr-controller builder & base images to be consistent with ART

### DIFF
--- a/openshift-kuryr-controller-rhel8.Dockerfile
+++ b/openshift-kuryr-controller-rhel8.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 
 ENV container=oci
 


### PR DESCRIPTION
Updating kuryr-controller builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/kuryr-controller.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
