### PR TITLE
Bug 1886871: Fix is_host_network() 

### DIFF
--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -80,7 +80,7 @@ def get_vifs(pod):
 
 
 def is_host_network(pod):
-    return pod['status'].get('hostNetwork', False)
+    return pod['spec'].get('hostNetwork', False)
 
 
 def get_pods(selector, namespace=None):


### PR DESCRIPTION
Seems like due to a mistake we've made is_host_network utility function
to always return False. This means that we considered hostNetworking
pods as regular one, ending up creating additional unused ports. Besides
that some anomalies regarding network policy could occur too as function
is used there.