### PR TITLE
Make cni_ds_init find correct conflist files

### DIFF
--- a/cni_ds_init
+++ b/cni_ds_init
@@ -9,11 +9,7 @@ function deploy() {
     # Copy the binary into the designated location
     cp /kuryr-cni "/opt/cni/bin/kuryr-cni"
     chmod +x /opt/cni/bin/kuryr-cni
-    if [ -f /etc/cni/net.d/kuryr.conflist.template ]; then
-      cp /etc/cni/net.d/kuryr.conflist.template /etc/cni/net.d/10-kuryr.conflist
-    else
-      cp /etc/kuryr-cni/kuryr.conflist.template /etc/cni/net.d/10-kuryr.conflist
-    fi
+    cp /etc/kuryr-cni/10-kuryr.conflist /etc/cni/net.d/10-kuryr.conflist
 }
 
 cleanup


### PR DESCRIPTION
Recently we made some changes to naming of CNI configurations in the
RPM. This commit makes sure cni_ds_init script looks for them in correct
location.