### PR TITLE
Bug 1893996: Fix duplicated sg rules on NP crd

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -311,11 +311,10 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 if sg_rule not in crd_rules:
                     crd_rules.append(sg_rule)
                 if direction == 'egress':
-                    rules = self._create_svc_egress_sg_rule(
-                        sg_id, policy_namespace, resource=resource,
-                        port=container_port,
+                    self._create_svc_egress_sg_rule(
+                        sg_id, policy_namespace, crd_rules,
+                        resource=resource, port=container_port,
                         protocol=port.get('protocol'))
-                    crd_rules.extend(rules)
 
     def _create_sg_rule_body_on_text_port(self, sg_id, direction, port,
                                           resources, crd_rules, pod_selector,
@@ -372,10 +371,9 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     pods=pods)
                 crd_rules.append(sg_rule)
             if direction == 'egress':
-                rules = self._create_svc_egress_sg_rule(
-                    sg_id, policy_namespace, port=container_port,
-                    protocol=port.get('protocol'))
-                crd_rules.extend(rules)
+                self._create_svc_egress_sg_rule(
+                    sg_id, policy_namespace, crd_rules,
+                    port=container_port, protocol=port.get('protocol'))
 
     def _create_sg_rule_on_number_port(self, allowed_resources, sg_id,
                                        direction, port, sg_rule_body_list,
@@ -395,10 +393,10 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     namespace=ns))
             sg_rule_body_list.append(sg_rule)
             if direction == 'egress':
-                rule = self._create_svc_egress_sg_rule(
-                    sg_id, policy_namespace, resource=resource,
-                    port=port.get('port'), protocol=port.get('protocol'))
-                sg_rule_body_list.extend(rule)
+                self._create_svc_egress_sg_rule(
+                    sg_id, policy_namespace, sg_rule_body_list,
+                    resource=resource, port=port.get('port'),
+                    protocol=port.get('protocol'))
 
     def _create_all_pods_sg_rules(self, port, sg_id, direction,
                                   sg_rule_body_list, pod_selector,
@@ -416,10 +414,10 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     protocol=port.get('protocol')))
             sg_rule_body_list.append(sg_rule)
             if direction == 'egress':
-                rule = self._create_svc_egress_sg_rule(
-                    sg_id, policy_namespace, port=port.get('port'),
+                self._create_svc_egress_sg_rule(
+                    sg_id, policy_namespace, sg_rule_body_list,
+                    port=port.get('port'),
                     protocol=port.get('protocol'))
-                sg_rule_body_list.extend(rule)
 
     def _create_default_sg_rule(self, sg_id, direction, sg_rule_body_list):
         default_rule = {
@@ -543,18 +541,17 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     sg_rule_body_list.append(rule)
                     if direction == 'egress':
                         rule = self._create_svc_egress_sg_rule(
-                            sg_id, policy_namespace, resource=resource)
-                        sg_rule_body_list.extend(rule)
+                            sg_id, policy_namespace, sg_rule_body_list,
+                            resource=resource)
                 if allow_all:
                     rule = driver_utils.create_security_group_rule_body(
                         sg_id, direction,
                         port_range_min=1,
                         port_range_max=65535)
-                    if direction == 'egress':
-                        rule = self._create_svc_egress_sg_rule(
-                            sg_id, policy_namespace)
-                        sg_rule_body_list.extend(rule)
                     sg_rule_body_list.append(rule)
+                    if direction == 'egress':
+                        self._create_svc_egress_sg_rule(
+                            sg_id, policy_namespace, sg_rule_body_list)
             else:
                 LOG.debug('This network policy specifies no %(direction)s '
                           '%(rule_direction)s and no ports: %(policy)s',
@@ -563,17 +560,17 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                            'policy': policy['metadata']['selfLink']})
 
     def _create_svc_egress_sg_rule(self, sg_id, policy_namespace,
-                                   resource=None, port=None,
-                                   protocol=None):
-        sg_rule_body_list = []
+                                   sg_rule_body_list, resource=None,
+                                   port=None, protocol=None):
         services = driver_utils.get_services()
         if not resource:
             svc_subnet = utils.get_subnet_cidr(
                 CONF.neutron_defaults.service_subnet)
             rule = driver_utils.create_security_group_rule_body(
                 sg_id, 'egress', port, protocol=protocol, cidr=svc_subnet)
-            sg_rule_body_list.append(rule)
-            return sg_rule_body_list
+            if rule not in sg_rule_body_list:
+                sg_rule_body_list.append(rule)
+            return
 
         for service in services.get('items'):
             if self._is_pod(resource):
@@ -606,8 +603,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
             rule = driver_utils.create_security_group_rule_body(
                 sg_id, 'egress', port, protocol=protocol,
                 cidr=cluster_ip)
-            sg_rule_body_list.append(rule)
-        return sg_rule_body_list
+            if rule not in sg_rule_body_list:
+                sg_rule_body_list.append(rule)
 
     def _pods_in_ip_block(self, pods, resource):
         for pod in pods:


### PR DESCRIPTION
While handling the creation of a Network
Policy it's possible that the CRD is patched
with repeated sg rules, which is not allowed
resulting in validation error as the repeated
sg rules will not have the sg rule id.

Closes-Bug: #1887167
Change-Id: Ia7814ddcea0d6948ff280a3e03a896bbc442891c