### PR TITLE
Bug 1894194: Delete ports created for host networking pods

### DIFF
--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -344,6 +344,22 @@ def get_networkpolicies(namespace=None):
     return nps.get('items', [])
 
 
+def zip_resources(xs, ys):
+    """Returns tuples of resources matched by namespace and name.
+
+    :param xs: List of objects x, first level of iteration.
+    :param ys: List of objects y.
+    :return: List of tuples of matching (x, y)
+    """
+    pairs = []
+    for x in xs:
+        for y in ys:
+            if utils.get_res_unique_name(x) == utils.get_res_unique_name(y):
+                pairs.append((x, y))
+                break
+    return pairs
+
+
 def zip_knp_np(knps, nps):
     """Returns tuples of matching KuryrNetworkPolicy and NetworkPolicy objs.
 
@@ -351,13 +367,7 @@ def zip_knp_np(knps, nps):
     :param nps: List of NetworkPolicy objects
     :return: List of tuples of matching (knp, np)
     """
-    pairs = []
-    for knp in knps:
-        for np in nps:
-            if utils.get_res_unique_name(knp) == utils.get_res_unique_name(np):
-                pairs.append((knp, np))
-                break
-    return pairs
+    return zip_resources(knps, nps)
 
 
 def match_expressions(expressions, labels):

--- a/kuryr_kubernetes/controller/handlers/kuryrport.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrport.py
@@ -148,7 +148,11 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
                 raise
             return
 
-        if 'deletionTimestamp' not in pod['metadata']:
+        # FIXME(dulek): hostNetwork condition can be removed once we know we
+        #               won't upgrade from version creating ports for host
+        #               networking pods.
+        if ('deletionTimestamp' not in pod['metadata'] and
+                not driver_utils.is_host_network(pod)):
             # NOTE(gryf): Ignore deleting KuryrPort, since most likely it was
             # removed manually, while we need vifs for corresponding pod
             # object which apperantely is still running.

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -45,6 +45,26 @@ class VIFHandler(k8s_base.ResourceEventHandler):
     def __init__(self):
         super(VIFHandler, self).__init__()
 
+        # NOTE(dulek): We should get rid of that once we're sure we won't
+        #              upgrade from a version that may have unnecessary ports
+        #              created for host networking pods.
+        self._delete_host_networking_ports()
+
+    def _delete_host_networking_ports(self):
+        k8s = clients.get_kubernetes_client()
+        pods = k8s.get('/api/v1/pods')['items']
+        kuryrports = k8s.get(constants.K8S_API_CRD_KURYRPORTS)['items']
+        pairs = driver_utils.zip_resources(kuryrports, pods)
+        for kuryrport, pod in pairs:
+            if driver_utils.is_host_network(pod):
+                LOG.warning(f'Found unnecessary KuryrPort '
+                            f'{utils.get_res_unique_name(kuryrport)} created '
+                            f'for host networking pod. Deleting it.')
+                try:
+                    k8s.delete(kuryrport['metadata']['selfLink'])
+                except k_exc.K8sResourceNotFound:
+                    pass
+
     def on_present(self, pod):
         if (driver_utils.is_host_network(pod) or
                 not self._is_pod_scheduled(pod)):


### PR DESCRIPTION
Due to bug 1899182 we were creating KuryrPorts and in consequence
Neutron ports for host networking pods. This is totally unnecessary and
those ports were not used at all. This commit makes sure even if version
with the bug was run, on kuryr-controller update those ports will get
deleted automatically.