### PR TITLE
Fix calculation of Ports availability in Subnet

### DIFF
--- a/kuryr_kubernetes/controller/managers/prometheus_exporter.py
+++ b/kuryr_kubernetes/controller/managers/prometheus_exporter.py
@@ -106,6 +106,10 @@ class ControllerPrometheusExporter(object):
                 ports_count = len(list(self._os_net.ports(
                     network_id=subnet.network_id,
                     project_id=self._project_id)))
+            # NOTE(maysams): As the allocation pools range does not take
+            # into account the Gateway IP, that port IP shouldn't
+            # also be include when counting the used ports.
+            ports_count = ports_count - 1
             labels = {'subnet_id': subnet.id, 'subnet_name': subnet.name}
             ports_availability = total_num_addresses-ports_count
             self.port_quota_per_subnet.labels(**labels).set(ports_availability)

--- a/kuryr_kubernetes/tests/unit/controller/managers/test_prometheus_exporter.py
+++ b/kuryr_kubernetes/tests/unit/controller/managers/test_prometheus_exporter.py
@@ -104,4 +104,4 @@ class TestControllerPrometheusExporter(base.TestCase):
         self.cls._record_ports_quota_per_subnet_metric(self.srv)
         self.srv.port_quota_per_subnet.labels.assert_called_with(
             **{'subnet_id': subnet_id, 'subnet_name': subnet_name})
-        self.srv.port_quota_per_subnet.labels().set.assert_called_with(508)
+        self.srv.port_quota_per_subnet.labels().set.assert_called_with(509)


### PR DESCRIPTION
The calculation of the number of Ports available in a Subnet is
current relying on the allocation range to verify the number of
Ports available. That range does not include the gateway Port.
However, when listing the Port in use we're are taking into account
the gateway Port, resulting in not more ports left when still there
is one. This commit fixes the issue by not including the gateway IP
on the calculation.