### PR TITLE
Bug 1897142: Ensure members are deleted from pools when there is no endpoints

### DIFF
--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -260,15 +260,16 @@ class EndpointsHandler(k8s_base.ResourceEventHandler):
         if self._move_annotations_to_crd(endpoints):
             return
 
-        if (not self._has_pods(endpoints) or
-                k_const.K8S_ANNOTATION_HEADLESS_SERVICE
+        k8s = clients.get_kubernetes_client()
+        loadbalancer_crd = k8s.get_loadbalancer_crd(endpoints)
+
+        if (not (self._has_pods(endpoints) or (loadbalancer_crd and
+                                               loadbalancer_crd.get('status')))
+                or k_const.K8S_ANNOTATION_HEADLESS_SERVICE
                 in endpoints['metadata'].get('labels', [])):
             LOG.debug("Ignoring Kubernetes endpoints %s",
                       endpoints['metadata']['name'])
             return
-
-        k8s = clients.get_kubernetes_client()
-        loadbalancer_crd = k8s.get_loadbalancer_crd(endpoints)
 
         if loadbalancer_crd is None:
             try:

--- a/kuryr_kubernetes/controller/handlers/loadbalancer.py
+++ b/kuryr_kubernetes/controller/handlers/loadbalancer.py
@@ -111,7 +111,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                         raise
 
     def _should_ignore(self, loadbalancer_crd):
-        return not(self._has_pods(loadbalancer_crd))
+        return not(self._has_pods(loadbalancer_crd) or
+                   loadbalancer_crd.get('status'))
 
     def _has_pods(self, loadbalancer_crd):
         ep_slices = loadbalancer_crd['spec'].get('endpointSlices', [])
@@ -171,8 +172,7 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
     def _sync_lbaas_members(self, loadbalancer_crd):
         changed = False
 
-        if (self._has_pods(loadbalancer_crd) and
-                self._remove_unused_members(loadbalancer_crd)):
+        if (self._remove_unused_members(loadbalancer_crd)):
             changed = True
 
         if self._sync_lbaas_pools(loadbalancer_crd):

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_loadbalancer.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_loadbalancer.py
@@ -344,12 +344,25 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
     def test_should_ignore(self):
         m_handler = mock.Mock(spec=h_lb.KuryrLoadBalancerHandler)
         m_handler._has_pods.return_value = True
+        loadbalancer_crd = get_lb_crd()
+        loadbalancer_crd['status'] = {}
 
         ret = h_lb.KuryrLoadBalancerHandler._should_ignore(
-            m_handler, get_lb_crd())
+            m_handler, loadbalancer_crd)
         self.assertEqual(False, ret)
 
-        m_handler._has_pods.assert_called_once_with(get_lb_crd())
+        m_handler._has_pods.assert_called_once_with(loadbalancer_crd)
+
+    def test_should_ignore_member_scale_to_0(self):
+        m_handler = mock.Mock(spec=h_lb.KuryrLoadBalancerHandler)
+        m_handler._has_pods.return_value = False
+        loadbalancer_crd = get_lb_crd()
+
+        ret = h_lb.KuryrLoadBalancerHandler._should_ignore(
+            m_handler, loadbalancer_crd)
+        self.assertEqual(False, ret)
+
+        m_handler._has_pods.assert_called_once_with(loadbalancer_crd)
 
     def test_has_pods(self):
         crd = get_lb_crd()


### PR DESCRIPTION
This patch ensures that endpoints scale down to 0 event is handled
and therefore members are deleted from the loadbalancer pool

Change-Id: Idb879245607a6f0f914a44220312d54aa40e2e3d
Closes-Bug: 1904395