### PR TITLE
Bug 1898906: Ensure members are deleted from pools when there is no endpoints

### DIFF
--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_lbaas.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_lbaas.py
@@ -599,9 +599,12 @@ class TestLoadBalancerHandler(test_base.TestCase):
         m_handler._drv_service_pub_ip.release_pub_ip.assert_called_once_with(
             lbaas_state.service_pub_ip_info)
 
-    def test_should_ignore(self):
+    @mock.patch('kuryr_kubernetes.utils.get_lbaas_state')
+    def test_should_ignore(self, m_get_lbaas_state):
         endpoints = mock.sentinel.endpoints
         lbaas_spec = mock.sentinel.lbaas_spec
+        lbaas_state = mock.sentinel.lbaas_state
+        m_get_lbaas_state.return_value = lbaas_state
 
         # REVISIT(ivc): ddt?
         m_handler = mock.Mock(spec=h_lbaas.LoadBalancerHandler)
@@ -612,9 +615,27 @@ class TestLoadBalancerHandler(test_base.TestCase):
             m_handler, endpoints, lbaas_spec)
         self.assertEqual(False, ret)
 
-        m_handler._has_pods.assert_called_once_with(endpoints)
+        m_handler._has_pods.assert_called()
         m_handler._svc_handler_annotations_updated.assert_called_once_with(
             endpoints, lbaas_spec)
+
+    @mock.patch('kuryr_kubernetes.utils.get_lbaas_state')
+    def test_should_ignore_member_scale_to_0(self, m_get_lbaas_state):
+        endpoints = mock.sentinel.endpoints
+        lbaas_spec = mock.sentinel.lbaas_spec
+        lbaas_state = mock.sentinel.lbaas_state
+        m_get_lbaas_state.return_value = lbaas_state
+
+        # REVISIT(ivc): ddt?
+        m_handler = mock.Mock(spec=h_lbaas.LoadBalancerHandler)
+        m_handler._has_pods.return_value = False
+        m_handler._svc_handler_annotations_updated.return_value = False
+
+        ret = h_lbaas.LoadBalancerHandler._should_ignore(
+            m_handler, endpoints, lbaas_spec)
+        self.assertEqual(False, ret)
+
+        m_handler._has_pods.assert_called()
 
     def test_has_pods(self):
         # REVISIT(ivc): ddt?


### PR DESCRIPTION
This patch ensures that endpoints scale down to 0 event is handled
and therefore members are deleted from the loadbalancer pool

Change-Id: I235ecaeb88b3990e0ef5bf27e2d878d415a3aceb
Closes-Bug: 1904395