### PR TITLE
Bug 1896696: Ensure leftover loadbalancer is cleaned up

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -778,6 +778,17 @@ class LBaaSv2Driver(base.LBaaSDriver):
         response_dict = response.json()[resource.resource_key]
         return resource(**response_dict)
 
+    def get_loadbalancers(self, request):
+        lbaas = clients.get_loadbalancer_client()
+        resource = o_lb.LoadBalancer
+        response = lbaas.get(resource.base_path, params=request)
+        if not response.ok:
+            LOG.error('Error when retrieving %s: %s', resource.resources_key,
+                      response.text)
+            response.raise_for_status()
+        response = response.json()[resource.resources_key]
+        return response
+
     def _create_loadbalancer(self, loadbalancer):
         request = {
             'name': loadbalancer.name,

--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -631,7 +631,6 @@ class LoadBalancerHandler(k8s_base.ResourceEventHandler):
         return changed
 
     def _cleanup_leftover_lbaas(self):
-        lbaas_client = clients.get_loadbalancer_client()
         services = []
         try:
             services = driver_utils.get_services().get('items')
@@ -644,11 +643,11 @@ class LoadBalancerHandler(k8s_base.ResourceEventHandler):
                                   if service['spec'].get('clusterIP'))
         lbaas_spec = {}
         self._drv_lbaas.add_tags('loadbalancer', lbaas_spec)
-        loadbalancers = lbaas_client.load_balancers(**lbaas_spec)
+        loadbalancers = self._drv_lbaas.get_loadbalancers(lbaas_spec)
         for loadbalancer in loadbalancers:
+            loadbalancer = obj_lbaas.LBaaSLoadBalancer(**loadbalancer)
             if loadbalancer.vip_address not in services_cluster_ip:
-                lb_obj = obj_lbaas.LBaaSLoadBalancer(**loadbalancer)
-                eventlet.spawn(self._ensure_release_lbaas, lb_obj)
+                eventlet.spawn(self._ensure_release_lbaas, loadbalancer)
 
     def _ensure_release_lbaas(self, lb_obj):
         attempts = 0


### PR DESCRIPTION
The openstacksdk version used (0.17.2) does
not support tags for loadbalancer. However, the
Octavia API does and the loadbalancers are
created with a tag. This commit ensures the
loadbalancer can be also filtered with tags
allowing the needed loadbalancers to get cleaned
up.