### PR TITLE
Bug 1889946: Bunch of CNI fixes related to cri-o

### DIFF
--- a/kuryr_kubernetes/cni/binding/nested.py
+++ b/kuryr_kubernetes/cni/binding/nested.py
@@ -13,9 +13,11 @@
 #    under the License.
 
 import abc
+import errno
 import six
 
 from oslo_log import log as logging
+import pyroute2
 
 from kuryr_kubernetes.cni.binding import base as b_base
 from kuryr_kubernetes import config
@@ -54,20 +56,41 @@ class NestedDriver(health.HealthHandler, b_base.BaseBindingDriver):
         with b_base.get_ipdb(netns) as c_ipdb:
             self._remove_ifaces(c_ipdb, (temp_name, ifname), netns)
 
+        # We might also have leftover interface in the host netns, let's try to
+        # remove it too. This is outside of the main host's IPDB context
+        # manager to make sure removal is commited before starting next
+        # transaction.
         with b_base.get_ipdb() as h_ipdb:
-            # TODO(vikasc): evaluate whether we should have stevedore
-            #               driver for getting the link device.
-            vm_iface_name = config.CONF.binding.link_iface
-
-            # We might also have leftover interface in the host netns, let's
-            # try to remove it too.
             self._remove_ifaces(h_ipdb, (temp_name,))
 
-            args = self._get_iface_create_args(vif)
-            with h_ipdb.create(ifname=temp_name,
-                               link=h_ipdb.interfaces[vm_iface_name],
-                               **args) as iface:
-                iface.net_ns_fd = utils.convert_netns(netns)
+        try:
+            with b_base.get_ipdb() as h_ipdb:
+                # TODO(vikasc): evaluate whether we should have stevedore
+                #               driver for getting the link device.
+                vm_iface_name = config.CONF.binding.link_iface
+
+                args = self._get_iface_create_args(vif)
+                with h_ipdb.create(ifname=temp_name,
+                                   link=h_ipdb.interfaces[vm_iface_name],
+                                   **args) as iface:
+                    iface.net_ns_fd = utils.convert_netns(netns)
+        except pyroute2.NetlinkError as e:
+            if e.code == errno.EEXIST:
+                # NOTE(dulek): This is related to bug 1854928. It's super-rare,
+                #              so aim of this piece is to gater any info useful
+                #              for determining when it happens.
+                LOG.exception('Creation of pod interface failed, most likely '
+                              'due to duplicated VLAN id. This will probably '
+                              'cause kuryr-daemon to crashloop. Trying to '
+                              'gather debugging information.')
+
+                with b_base.get_ipdb() as h_ipdb:
+                    LOG.error('List of host interfaces: %s', h_ipdb.interfaces)
+
+                with b_base.get_ipdb(netns) as c_ipdb:
+                    LOG.error('List of pod namespace interfaces: %s',
+                              c_ipdb.interfaces)
+            raise
 
         with b_base.get_ipdb(netns) as c_ipdb:
             with c_ipdb.interfaces[temp_name] as iface:

--- a/kuryr_kubernetes/cni/binding/nested.py
+++ b/kuryr_kubernetes/cni/binding/nested.py
@@ -100,9 +100,13 @@ class NestedDriver(health.HealthHandler, b_base.BaseBindingDriver):
                 iface.up()
 
     def disconnect(self, vif, ifname, netns, container_id):
-        # NOTE(vikasc): device will get deleted with container namespace, so
-        # nothing to be done here.
-        pass
+        # NOTE(dulek): Interfaces should get deleted with the netns, but it may
+        #              happen that kubelet or crio will call new CNI ADD before
+        #              the old netns is deleted. This might result in VLAN ID
+        #              conflict. In oder to protect from that let's remove the
+        #              netns ifaces here anyway.
+        with b_base.get_ipdb(netns) as c_ipdb:
+            self._remove_ifaces(c_ipdb, (vif.vif_name, ifname), netns)
 
 
 class VlanDriver(NestedDriver):

--- a/kuryr_kubernetes/cni/binding/nested.py
+++ b/kuryr_kubernetes/cni/binding/nested.py
@@ -79,17 +79,12 @@ class NestedDriver(health.HealthHandler, b_base.BaseBindingDriver):
                 # NOTE(dulek): This is related to bug 1854928. It's super-rare,
                 #              so aim of this piece is to gater any info useful
                 #              for determining when it happens.
-                LOG.exception('Creation of pod interface failed, most likely '
-                              'due to duplicated VLAN id. This will probably '
-                              'cause kuryr-daemon to crashloop. Trying to '
-                              'gather debugging information.')
-
-                with b_base.get_ipdb() as h_ipdb:
-                    LOG.error('List of host interfaces: %s', h_ipdb.interfaces)
-
-                with b_base.get_ipdb(netns) as c_ipdb:
-                    LOG.error('List of pod namespace interfaces: %s',
-                              c_ipdb.interfaces)
+                LOG.exception('Creation of pod interface failed due to VLAN '
+                              'ID (vlan_info=%s) conflict. Probably the '
+                              'CRI had not cleaned up the network namespace '
+                              'of deleted pods. This should not be a '
+                              'permanent issue but may cause restart of '
+                              'kuryr-cni pod.', args)
             raise
 
         with b_base.get_ipdb(netns) as c_ipdb:

--- a/kuryr_kubernetes/cni/daemon/service.py
+++ b/kuryr_kubernetes/cni/daemon/service.py
@@ -103,10 +103,10 @@ class DaemonServer(object):
             self.plugin.delete(params)
         except exceptions.ResourceNotReady:
             # NOTE(dulek): It's better to ignore this error - most of the time
-            #              it will happen when pod is long gone and kubelet
+            #              it will happen when pod is long gone and CRI
             #              overzealously tries to delete it from the network.
             #              We cannot really do anything without VIF annotation,
-            #              so let's just tell kubelet to move along.
+            #              so let's just tell CRI to move along.
             LOG.warning('Error when processing delNetwork request. '
                         'Ignoring this error, pod is most likely gone')
             return '', httplib.NO_CONTENT, self.headers

--- a/kuryr_kubernetes/cni/daemon/service.py
+++ b/kuryr_kubernetes/cni/daemon/service.py
@@ -220,7 +220,9 @@ class CNIDaemonWatcherService(cotyledon.Service):
         # NOTE(dulek): We need a lock when modifying shared self.registry dict
         #              to prevent race conditions with other processes/threads.
         with lockutils.lock(pod_name, external=True):
-            if pod_name not in self.registry:
+            if (pod_name not in self.registry or
+                    self.registry[pod_name]['pod']['metadata']['uid']
+                    != pod['metadata']['uid']):
                 self.registry[pod_name] = {'pod': pod, 'vifs': vif_dict,
                                            'containerid': None}
             else:

--- a/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
+++ b/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
@@ -102,6 +102,23 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
         except KeyError:
             pass
         self._do_work(params, b_base.disconnect)
+        # NOTE(ndesh): We need to lock here to avoid race condition
+        #              with the deletion code in the watcher to ensure that
+        #              we delete the registry entry exactly once
+        try:
+            with lockutils.lock(pod_name, external=True):
+                if self.registry[pod_name]['del_received']:
+                    del self.registry[pod_name]
+                else:
+                    pod_dict = self.registry[pod_name]
+                    pod_dict['vif_unplugged'] = True
+                    self.registry[pod_name] = pod_dict
+        except KeyError:
+            # This means the pod was removed before vif was unplugged. This
+            # shouldn't happen, but we can't do anything about it now
+            LOG.debug('Pod %s not found registry while handling DEL request. '
+                      'Ignoring.', pod_name)
+            pass
 
     def report_drivers_health(self, driver_healthy):
         if not driver_healthy:

--- a/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
+++ b/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
@@ -50,9 +50,28 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
             'name': params.args.K8S_POD_NAME}
 
     def add(self, params):
-        vifs = self._do_work(params, b_base.connect, confirm=True)
-
         pod_name = self._get_pod_name(params)
+        timeout = CONF.cni_daemon.vif_annotation_timeout
+
+        # Try to confirm if pod in the registry is not stale cache. If it is,
+        # remove it.
+        with lockutils.lock(pod_name, external=True):
+            if pod_name in self.registry:
+                cached_pod = self.registry[pod_name]['pod']
+                try:
+                    pod = self.k8s.get(cached_pod['metadata']['selfLink'])
+                except Exception:
+                    LOG.exception('Error when getting pod %s', pod_name)
+                    raise exceptions.ResourceNotReady(pod_name)
+
+                if pod['metadata']['uid'] != cached_pod['metadata']['uid']:
+                    LOG.warning('Stale pod %s detected in cache. (API '
+                                'uid=%s, cached uid=%s). Removing it from '
+                                'cache.', pod_name, pod['metadata']['uid'],
+                                cached_pod['metadata']['uid'])
+                    del self.registry[pod_name]
+
+        vifs = self._do_work(params, b_base.connect, timeout)
 
         # NOTE(dulek): Saving containerid to be able to distinguish old DEL
         #              requests that we should ignore. We need a lock to
@@ -64,9 +83,6 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
             self.registry[pod_name] = d
             LOG.debug('Saved containerid = %s for pod %s',
                       params.CNI_CONTAINERID, pod_name)
-
-        # Wait for VIFs to become active.
-        timeout = CONF.cni_daemon.vif_annotation_timeout
 
         # Wait for timeout sec, 1 sec between tries, retry when even one
         # vif is not active.
@@ -96,12 +112,20 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
                 # NOTE(dulek): This is a DEL request for some older (probably
                 #              failed) ADD call. We should ignore it or we'll
                 #              unplug a running pod.
-                LOG.warning('Received DEL request for unknown ADD call. '
-                            'Ignoring.')
+                LOG.warning('Received DEL request for unknown ADD call for '
+                            'pod %s (CNI_CONTAINERID=%s). Ignoring.', pod_name,
+                            params.CNI_CONTAINERID)
                 return
         except KeyError:
             pass
-        self._do_work(params, b_base.disconnect)
+
+        # Passing arbitrary 5 seconds as timeout, as it does not make any sense
+        # to wait on CNI DEL. If pod got deleted from API - VIF info is gone.
+        # If pod got the annotation removed - it is now gone too. The number's
+        # not 0, because we need to anticipate for restarts and delay before
+        # registry is populated by watcher.
+        self._do_work(params, b_base.disconnect, 5)
+
         # NOTE(ndesh): We need to lock here to avoid race condition
         #              with the deletion code in the watcher to ensure that
         #              we delete the registry entry exactly once
@@ -126,28 +150,8 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
                 LOG.debug("Reporting CNI driver not healthy.")
                 self.healthy.value = driver_healthy
 
-    def _do_work(self, params, fn, confirm=False):
+    def _do_work(self, params, fn, timeout):
         pod_name = self._get_pod_name(params)
-
-        timeout = CONF.cni_daemon.vif_annotation_timeout
-
-        if confirm:
-            # Try to confirm if pod in the registry is not stale cache.
-            with lockutils.lock(pod_name, external=True):
-                if pod_name in self.registry:
-                    cached_pod = self.registry[pod_name]['pod']
-                    try:
-                        pod = self.k8s.get(cached_pod['metadata']['selfLink'])
-                    except Exception:
-                        LOG.exception('Error when getting pod %s', pod_name)
-                        raise exceptions.ResourceNotReady(pod_name)
-
-                    if pod['metadata']['uid'] != cached_pod['metadata']['uid']:
-                        LOG.warning('Stale pod %s detected in cache. (API '
-                                    'uid=%s, cached uid=%s). Removing it from '
-                                    'cache.', pod_name, pod['metadata']['uid'],
-                                    cached_pod['metadata']['uid'])
-                        del self.registry[pod_name]
 
         # In case of KeyError retry for `timeout` s, wait 1 s between tries.
         @retrying.retry(stop_max_delay=timeout * 1000, wait_fixed=RETRY_DELAY,

--- a/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
+++ b/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
@@ -20,6 +20,7 @@ from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_log import log as logging
 
+from kuryr_kubernetes import clients
 from kuryr_kubernetes.cni.binding import base as b_base
 from kuryr_kubernetes.cni.plugins import base as base_cni
 from kuryr_kubernetes import constants as k_const
@@ -41,6 +42,7 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
     def __init__(self, registry, healthy):
         self.healthy = healthy
         self.registry = registry
+        self.k8s = clients.get_kubernetes_client()
 
     def _get_pod_name(self, params):
         return "%(namespace)s/%(name)s" % {
@@ -48,7 +50,7 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
             'name': params.args.K8S_POD_NAME}
 
     def add(self, params):
-        vifs = self._do_work(params, b_base.connect)
+        vifs = self._do_work(params, b_base.connect, confirm=True)
 
         pod_name = self._get_pod_name(params)
 
@@ -107,10 +109,28 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
                 LOG.debug("Reporting CNI driver not healthy.")
                 self.healthy.value = driver_healthy
 
-    def _do_work(self, params, fn):
+    def _do_work(self, params, fn, confirm=False):
         pod_name = self._get_pod_name(params)
 
         timeout = CONF.cni_daemon.vif_annotation_timeout
+
+        if confirm:
+            # Try to confirm if pod in the registry is not stale cache.
+            with lockutils.lock(pod_name, external=True):
+                if pod_name in self.registry:
+                    cached_pod = self.registry[pod_name]['pod']
+                    try:
+                        pod = self.k8s.get(cached_pod['metadata']['selfLink'])
+                    except Exception:
+                        LOG.exception('Error when getting pod %s', pod_name)
+                        raise exceptions.ResourceNotReady(pod_name)
+
+                    if pod['metadata']['uid'] != cached_pod['metadata']['uid']:
+                        LOG.warning('Stale pod %s detected in cache. (API '
+                                    'uid=%s, cached uid=%s). Removing it from '
+                                    'cache.', pod_name, pod['metadata']['uid'],
+                                    cached_pod['metadata']['uid'])
+                        del self.registry[pod_name]
 
         # In case of KeyError retry for `timeout` s, wait 1 s between tries.
         @retrying.retry(stop_max_delay=timeout * 1000, wait_fixed=RETRY_DELAY,

--- a/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
+++ b/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
@@ -31,7 +31,9 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                                  'namespace': 'default', 'selfLink': 'baz'}}
         self.vifs = fake._fake_vifs_dict()
         registry = {'default/foo': {'pod': self.pod, 'vifs': self.vifs,
-                                    'containerid': None}}
+                                    'containerid': None,
+                                    'vif_unplugged': False,
+                                    'del_received': False}}
         healthy = mock.Mock()
         self.plugin = k8s_cni_registry.K8sCNIRegistryPlugin(registry, healthy)
         self.params = mock.Mock(args=mock.Mock(K8S_POD_NAME='foo',
@@ -54,14 +56,32 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
         self.assertEqual('cont_id',
                          self.plugin.registry['default/foo']['containerid'])
 
+    @mock.patch('oslo_concurrency.lockutils.lock')
     @mock.patch('kuryr_kubernetes.cni.binding.base.disconnect')
-    def test_del_present(self, m_disconnect):
+    def test_del_present(self, m_disconnect, m_lock):
         self.plugin.delete(self.params)
 
+        m_lock.assert_called_with('default/foo', external=True)
         m_disconnect.assert_called_with(mock.ANY, mock.ANY, 'eth0', 123,
                                         report_health=mock.ANY,
                                         is_default_gateway=mock.ANY,
                                         container_id='cont_id')
+        self.assertIn('default/foo', self.plugin.registry)
+        self.assertEqual(True,
+                         self.plugin.registry['default/foo']['vif_unplugged'])
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    @mock.patch('kuryr_kubernetes.cni.binding.base.disconnect')
+    def test_remove_pod_from_registry_after_del(self, m_disconnect, m_lock):
+        self.plugin.registry['default/foo']['del_received'] = True
+        self.plugin.delete(self.params)
+
+        m_lock.assert_called_with('default/foo', external=True)
+        m_disconnect.assert_called_with(mock.ANY, mock.ANY, 'eth0', 123,
+                                        report_health=mock.ANY,
+                                        is_default_gateway=mock.ANY,
+                                        container_id='cont_id')
+        self.assertNotIn('default/foo', self.plugin.registry)
 
     @mock.patch('kuryr_kubernetes.cni.binding.base.disconnect')
     def test_del_wrong_container_id(self, m_disconnect):
@@ -78,9 +98,12 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
     @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
     def test_add_present_on_5_try(self, m_connect, m_lock):
         se = [KeyError] * 5
-        se.append({'pod': self.pod, 'vifs': self.vifs, 'containerid': None})
-        se.append({'pod': self.pod, 'vifs': self.vifs, 'containerid': None})
-        se.append({'pod': self.pod, 'vifs': self.vifs, 'containerid': None})
+        se.append({'pod': self.pod, 'vifs': self.vifs, 'containerid': None,
+                   'vif_unplugged': False, 'del_received': False})
+        se.append({'pod': self.pod, 'vifs': self.vifs, 'containerid': None,
+                   'vif_unplugged': False, 'del_received': False})
+        se.append({'pod': self.pod, 'vifs': self.vifs, 'containerid': None,
+                   'vif_unplugged': False, 'del_received': False})
         m_getitem = mock.Mock(side_effect=se)
         m_setitem = mock.Mock()
         m_registry = mock.Mock(__getitem__=m_getitem, __setitem__=m_setitem,
@@ -92,7 +115,9 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
         m_setitem.assert_called_once_with('default/foo',
                                           {'pod': self.pod,
                                            'vifs': self.vifs,
-                                           'containerid': 'cont_id'})
+                                           'containerid': 'cont_id',
+                                           'vif_unplugged': False,
+                                           'del_received': False})
         m_connect.assert_called_with(mock.ANY, mock.ANY, 'eth0', 123,
                                      report_health=mock.ANY,
                                      is_default_gateway=mock.ANY,

--- a/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
+++ b/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
@@ -20,13 +20,15 @@ from kuryr_kubernetes.cni.plugins import k8s_cni_registry
 from kuryr_kubernetes import exceptions
 from kuryr_kubernetes.tests import base
 from kuryr_kubernetes.tests import fake
+from kuryr_kubernetes.tests.unit import kuryr_fixtures
 
 
 class TestK8sCNIRegistryPlugin(base.TestCase):
     def setUp(self):
         super(TestK8sCNIRegistryPlugin, self).setUp()
+        self.k8s_mock = self.useFixture(kuryr_fixtures.MockK8sClient()).client
         self.pod = {'metadata': {'name': 'foo', 'uid': 'bar',
-                                 'namespace': 'default'}}
+                                 'namespace': 'default', 'selfLink': 'baz'}}
         self.vifs = fake._fake_vifs_dict()
         registry = {'default/foo': {'pod': self.pod, 'vifs': self.vifs,
                                     'containerid': None}}
@@ -40,6 +42,8 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
     @mock.patch('oslo_concurrency.lockutils.lock')
     @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
     def test_add_present(self, m_connect, m_lock):
+        self.k8s_mock.get.return_value = self.pod
+
         self.plugin.add(self.params)
 
         m_lock.assert_called_with('default/foo', external=True)
@@ -79,7 +83,8 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
         se.append({'pod': self.pod, 'vifs': self.vifs, 'containerid': None})
         m_getitem = mock.Mock(side_effect=se)
         m_setitem = mock.Mock()
-        m_registry = mock.Mock(__getitem__=m_getitem, __setitem__=m_setitem)
+        m_registry = mock.Mock(__getitem__=m_getitem, __setitem__=m_setitem,
+                               __contains__=mock.Mock(return_value=False))
         self.plugin.registry = m_registry
         self.plugin.add(self.params)
 
@@ -94,13 +99,15 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                                      container_id='cont_id')
 
     @mock.patch('time.sleep', mock.Mock())
+    @mock.patch('oslo_concurrency.lockutils.lock', mock.Mock(
+        return_value=mock.Mock(__enter__=mock.Mock(), __exit__=mock.Mock())))
     def test_add_not_present(self):
         cfg.CONF.set_override('vif_annotation_timeout', 0, group='cni_daemon')
         self.addCleanup(cfg.CONF.set_override, 'vif_annotation_timeout', 120,
                         group='cni_daemon')
 
         m_getitem = mock.Mock(side_effect=KeyError)
-        m_registry = mock.Mock(__getitem__=m_getitem)
+        m_registry = mock.Mock(__getitem__=m_getitem, __contains__=False)
         self.plugin.registry = m_registry
         self.assertRaises(exceptions.ResourceNotReady, self.plugin.add,
                           self.params)

--- a/kuryr_kubernetes/tests/unit/cni/test_binding.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_binding.py
@@ -91,8 +91,13 @@ class TestDriverMixin(test_base.TestCase):
         if report:
             report.assert_called_once()
 
+    @mock.patch('kuryr_kubernetes.cni.binding.base.get_ipdb')
     @mock.patch('os_vif.unplug')
-    def _test_disconnect(self, m_vif_unplug, report=None):
+    def _test_disconnect(self, m_vif_unplug, m_get_ipdb, report=None):
+        def get_ipdb(netns=None):
+            return self.ipdbs[netns]
+        m_get_ipdb.side_effect = get_ipdb
+
         base.disconnect(self.vif, self.instance_info, self.ifname, self.netns,
                         report)
         m_vif_unplug.assert_called_once_with(self.vif, self.instance_info)

--- a/kuryr_kubernetes/tests/unit/cni/test_binding.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_binding.py
@@ -176,7 +176,7 @@ class TestNestedVlanDriver(TestDriverMixin, test_base.TestCase):
         self._test_connect()
 
         self.assertEqual(1, self.h_ipdb_exit.call_count)
-        self.assertEqual(2, self.c_ipdb_exit.call_count)
+        self.assertEqual(3, self.c_ipdb_exit.call_count)
 
         self.assertEqual(self.ifname, self.m_h_iface.ifname)
         self.assertEqual(1, self.m_h_iface.mtu)
@@ -198,7 +198,7 @@ class TestNestedMacvlanDriver(TestDriverMixin, test_base.TestCase):
         self._test_connect()
 
         self.assertEqual(1, self.h_ipdb_exit.call_count)
-        self.assertEqual(2, self.c_ipdb_exit.call_count)
+        self.assertEqual(3, self.c_ipdb_exit.call_count)
 
         self.assertEqual(self.ifname, self.m_h_iface.ifname)
         self.assertEqual(1, self.m_h_iface.mtu)

--- a/kuryr_kubernetes/tests/unit/cni/test_binding.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_binding.py
@@ -175,7 +175,7 @@ class TestNestedVlanDriver(TestDriverMixin, test_base.TestCase):
     def test_connect(self):
         self._test_connect()
 
-        self.assertEqual(1, self.h_ipdb_exit.call_count)
+        self.assertEqual(2, self.h_ipdb_exit.call_count)
         self.assertEqual(3, self.c_ipdb_exit.call_count)
 
         self.assertEqual(self.ifname, self.m_h_iface.ifname)
@@ -197,7 +197,7 @@ class TestNestedMacvlanDriver(TestDriverMixin, test_base.TestCase):
     def test_connect(self):
         self._test_connect()
 
-        self.assertEqual(1, self.h_ipdb_exit.call_count)
+        self.assertEqual(2, self.h_ipdb_exit.call_count)
         self.assertEqual(3, self.c_ipdb_exit.call_count)
 
         self.assertEqual(self.ifname, self.m_h_iface.ifname)

--- a/kuryr_kubernetes/tests/unit/cni/test_service.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_service.py
@@ -21,12 +21,14 @@ from kuryr_kubernetes.cni.plugins import k8s_cni_registry
 from kuryr_kubernetes import exceptions
 from kuryr_kubernetes.tests import base
 from kuryr_kubernetes.tests import fake
+from kuryr_kubernetes.tests.unit import kuryr_fixtures
 
 
 class TestDaemonServer(base.TestCase):
     def setUp(self):
         super(TestDaemonServer, self).setUp()
         healthy = mock.Mock()
+        self.k8s_mock = self.useFixture(kuryr_fixtures.MockK8sClient())
         self.plugin = k8s_cni_registry.K8sCNIRegistryPlugin({}, healthy)
         self.health_registry = mock.Mock()
         self.srv = service.DaemonServer(self.plugin, self.health_registry)

--- a/kuryr_kubernetes/tests/unit/cni/test_service.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_service.py
@@ -103,3 +103,34 @@ class TestDaemonServer(base.TestCase):
 
         m_delete.assert_called_once_with(mock.ANY)
         self.assertEqual(500, resp.status_code)
+
+
+class TestCNIDaemonWatcherService(base.TestCase):
+    def setUp(self):
+        super(TestCNIDaemonWatcherService, self).setUp()
+        self.registry = {}
+        self.pod = {'metadata': {'namespace': 'testing',
+                                 'name': 'default'},
+                    'vif_unplugged': False,
+                    'del_receieved': False}
+        self.healthy = mock.Mock()
+        self.watcher = service.CNIDaemonWatcherService(
+            0, self.registry, self.healthy)
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_on_deleted(self, m_lock):
+        pod = self.pod
+        pod['vif_unplugged'] = True
+        pod_name = 'testing/default'
+        self.registry[pod_name] = pod
+        self.watcher.on_deleted(pod)
+        self.assertNotIn(pod_name, self.registry)
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_on_deleted_false(self, m_lock):
+        pod = self.pod
+        pod_name = 'testing/default'
+        self.registry[pod_name] = pod
+        self.watcher.on_deleted(pod)
+        self.assertIn(pod_name, self.registry)
+        self.assertIs(True, pod['del_received'])


### PR DESCRIPTION
As cri-o is the 4.3+ default CRI we did a ton of fixes to mitigate changes in how CNI calls kuryr-cni. This PR tries to backport them into the 3.11 branch to improve cri-o support there.