### PR TITLE
Bug 1890630: Fix alert value for ports available on Subnet

### DIFF
--- a/kuryr_kubernetes/controller/managers/prometheus_exporter.py
+++ b/kuryr_kubernetes/controller/managers/prometheus_exporter.py
@@ -103,12 +103,12 @@ class ControllerPrometheusExporter(object):
                 total_num_addresses += netaddr.IPRange(
                     netaddr.IPAddress(allocation['start']),
                     netaddr.IPAddress(allocation['end'])).size
-                ports_count = len(list(self._os_net.ports(
-                    network_id=subnet.network_id,
-                    project_id=self._project_id)))
+            ports_count = len(list(self._os_net.ports(
+                fixed_ips=[f'subnet_id={subnet.id}'],
+                project_id=self._project_id)))
             # NOTE(maysams): As the allocation pools range does not take
             # into account the Gateway IP, that port IP shouldn't
-            # also be include when counting the used ports.
+            # be include when counting the used ports.
             ports_count = ports_count - 1
             labels = {'subnet_id': subnet.id, 'subnet_name': subnet.name}
             ports_availability = total_num_addresses-ports_count


### PR DESCRIPTION
This commit fixes the port usage on subnet, by
excluding from the amount of ports used the
ports not allocated on the subnet.

Depends-on: #422 