### PR TITLE
Bug 1904973: Skip unscheduled pods when deleting NPs

### DIFF
--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -83,6 +83,13 @@ def is_host_network(pod):
     return pod['spec'].get('hostNetwork', False)
 
 
+def is_pod_scheduled(pod):
+    try:
+        return bool(pod['spec']['nodeName'])
+    except KeyError:
+        return False
+
+
 def get_pods(selector, namespace=None):
     """Return a k8s object list with the pods matching the selector.
 

--- a/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
@@ -273,7 +273,8 @@ class KuryrNetworkPolicyHandler(k8s_base.ResourceEventHandler):
 
         if crd_sg:
             for pod in pods_to_update:
-                if driver_utils.is_host_network(pod):
+                if (driver_utils.is_host_network(pod)
+                        or not driver_utils.is_pod_scheduled(pod)):
                     continue
                 pod_sgs = self._drv_pod_sg.get_security_groups(pod, project_id)
                 if crd_sg in pod_sgs:


### PR DESCRIPTION
It may happen that there's an unscheduled pod matching a policy when NP
is getting deleted. In that case we'll get a traceback as pod has no
nodeName set. This commit fixes that by making sure we skip unscheduled
pods when detaching SGs from ports on NP deletion.