### PR TITLE
Bug 1904973: Skip unscheduled pods when handling NP creation

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
@@ -197,7 +197,8 @@ class KuryrNetworkPolicyHandler(k8s_base.ResourceEventHandler):
         pods_to_update.extend(matched_pods)
 
         for pod in pods_to_update:
-            if driver_utils.is_host_network(pod):
+            if (driver_utils.is_host_network(pod) or
+                    not driver_utils.is_pod_scheduled(pod)):
                 continue
             pod_sgs = self._drv_pod_sg.get_security_groups(pod, project_id)
             try:


### PR DESCRIPTION
This is follow up to dce5939c242d44417b74e00382fd0a08a8c34f7b, as
apparently same problem can happen on NP creation. This patch makes sure
we skip unscheduled pods there too.