### PR TITLE
Bug 1915885: Support multiple nodes subnets

### DIFF
--- a/doc/source/installation/containerized.rst
+++ b/doc/source/installation/containerized.rst
@@ -80,7 +80,7 @@ script. Below is the list of available variables:
 * ``$KURYR_K8S_POD_SUBNET_ID`` - ``[neutron_defaults]pod_subnet_id``
 * ``$KURYR_K8S_POD_SG`` - ``[neutron_defaults]pod_sg``
 * ``$KURYR_K8S_SERVICE_SUBNET_ID`` - ``[neutron_defaults]service_subnet_id``
-* ``$KURYR_K8S_WORKER_NODES_SUBNET`` - ``[pod_vif_nested]worker_nodes_subnet``
+* ``$KURYR_K8S_WORKER_NODES_SUBNETS`` - ``[pod_vif_nested]worker_nodes_subnets``
 * ``$KURYR_K8S_BINDING_DRIVER`` - ``[binding]driver`` (default:
   ``kuryr.lib.binding.drivers.vlan``)
 * ``$KURYR_K8S_BINDING_IFACE`` - ``[binding]link_iface`` (default: eth0)

--- a/doc/source/installation/devstack/nested-macvlan.rst
+++ b/doc/source/installation/devstack/nested-macvlan.rst
@@ -28,7 +28,7 @@ nested MACVLAN driver rather than VLAN and trunk ports.
      .. code-block:: ini
 
         [pod_vif_nested]
-        worker_nodes_subnet = <UNDERCLOUD_SUBNET_WORKER_NODES_UUID>
+        worker_nodes_subnets = <UNDERCLOUD_SUBNET_WORKER_NODES_UUID>
 
    - Configure "pod_vif_driver" as "nested-macvlan":
 

--- a/doc/source/installation/devstack/nested-vlan.rst
+++ b/doc/source/installation/devstack/nested-vlan.rst
@@ -64,7 +64,7 @@ for the VM:
       .. code-block:: ini
 
          [pod_vif_nested]
-         worker_nodes_subnet = <UNDERCLOUD_SUBNET_WORKER_NODES_UUID>
+         worker_nodes_subnets = <UNDERCLOUD_SUBNET_WORKER_NODES_UUID>
 
    - Configure binding section:
 

--- a/doc/source/nested_vlan_mode.rst
+++ b/doc/source/nested_vlan_mode.rst
@@ -1,0 +1,66 @@
+=================================
+Kuryr-Kubernetes nested VLAN mode
+=================================
+
+Kuryr-Kubernetes can work in two basic modes - nested and standalone. The main
+use case of the project, which is to support Kubernetes running on OpenStack
+VMs is implemented with nested mode. The standalone mode is mostly used for
+testing.
+
+This document describes nested VLAN mode.
+
+
+Requirements
+============
+
+Nested VLAN mode requires Neutron to have `trunk` extension enabled, which adds
+trunk port functionality to Neutron API.
+
+
+Principle
+=========
+
+This mode aims at use case of kuryr-kubernetes providing networking for a
+Kubernetes cluster running in VMs on OpenStack.
+
+.. note::
+
+   A natural consideration here is running kuryr-kubernetes in containers on
+   that K8s cluster. For more see :ref:`containerized` section.
+
+The principle of nested VLAN is that Kuryr-Kubernetes will require that main
+interface of the K8s worker VMs is a trunk port. Then each of the pods will
+get a subport of that attached into its network namespace.
+
+
+How to configure
+================
+
+You need to set several options in the kuryr.conf:
+
+.. code-block:: ini
+
+   [binding]
+   default_driver = kuryr.lib.binding.drivers.vlan
+   # Name of the trunk port interface on VMs. If not provided Kuryr will try
+   # to autodetect it.
+   link_iface = ens3
+
+   [kubernetes]
+   pod_vif_driver = nested-vlan
+   vif_pool_driver = nested  # If using port pools.
+
+   [pod_vif_nested]
+   # ID of the subnet in which worker node VMs are running (if multiple join
+   # with a comma).
+   worker_nodes_subnets = <id>
+
+Also if you want to run several Kubernetes cluster in one OpenStack tenant you
+need to make sure Kuryr-Kubernetes instances are able to distinguish their own
+resources from resources created by other instances. In order to do that you
+need to configure Kuryr-Kubernetes to tag resources with unique ID:
+
+.. code-block:: ini
+
+   [neutron_defaults]
+   resource_tags = <unique-id-of-the-K8s-cluster>

--- a/kuryr_kubernetes/config.py
+++ b/kuryr_kubernetes/config.py
@@ -142,6 +142,9 @@ k8s_opts = [
                help=_("The driver that manages VIFs pools for "
                       "Kubernetes Pods"),
                default='noop'),
+    cfg.StrOpt('nodes_subnets_driver',
+               help=_("The driver that manages listing K8s nodes subnet_ids."),
+               default='config'),
     cfg.BoolOpt('port_debug',
                 help=_('Enable port debug to force kuryr port names to be '
                        'set to their corresponding pod names.'),

--- a/kuryr_kubernetes/config.py
+++ b/kuryr_kubernetes/config.py
@@ -268,9 +268,11 @@ cache_defaults = [
 ]
 
 nested_vif_driver_opts = [
-    cfg.StrOpt('worker_nodes_subnet',
-               help=_("Neutron subnet ID for k8s worker node vms."),
-               default=''),
+    cfg.ListOpt('worker_nodes_subnets',
+                help=_("Neutron subnet IDs for k8s worker node VMs."),
+                default=[],
+                deprecated_name='worker_nodes_subnet',
+                deprecated_group='pod_vif_nested'),
     cfg.IntOpt('rev_update_attempts',
                help=_("How many time to try to re-update the neutron resource "
                       "when revision has been changed by other thread"),

--- a/kuryr_kubernetes/constants.py
+++ b/kuryr_kubernetes/constants.py
@@ -43,6 +43,9 @@ K8S_OBJ_KURYRNETWORKPOLICY = 'KuryrNetworkPolicy'
 K8S_OBJ_KURYRLOADBALANCER = 'KuryrLoadBalancer'
 K8S_OBJ_KURYRPORT = 'KuryrPort'
 
+OPENSHIFT_OBJ_MACHINE = 'Machine'
+OPENSHIFT_API_CRD_MACHINES = '/apis/machine.openshift.io/v1beta1/machines'
+
 K8S_POD_STATUS_PENDING = 'Pending'
 K8S_POD_STATUS_SUCCEEDED = 'Succeeded'
 K8S_POD_STATUS_FAILED = 'Failed'

--- a/kuryr_kubernetes/controller/drivers/base.py
+++ b/kuryr_kubernetes/controller/drivers/base.py
@@ -751,3 +751,35 @@ class NetworkPolicyProjectDriver(DriverBase, metaclass=abc.ABCMeta):
         :returns: OpenStack project_id
         """
         raise NotImplementedError()
+
+
+class NodesSubnetsDriver(DriverBase, metaclass=abc.ABCMeta):
+    """Keeps list of subnet_ids of the OpenShift Nodes."""
+
+    ALIAS = 'nodes_subnets'
+
+    @abc.abstractmethod
+    def get_nodes_subnets(self, raise_on_empty=False):
+        """Gets list of subnet_ids of OpenShift Nodes.
+
+        :param raise_on_empty: whether it should raise if list is empty.
+        :return: list of subnets
+        """
+
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def add_node(self, node):
+        """Handles node addition.
+
+        :param node: Node object
+        """
+        pass
+
+    @abc.abstractmethod
+    def delete_node(self, node):
+        """Handles node removal
+
+        :param node: Node object
+        """
+        pass

--- a/kuryr_kubernetes/controller/drivers/nested_vif.py
+++ b/kuryr_kubernetes/controller/drivers/nested_vif.py
@@ -23,6 +23,7 @@ from kuryr_kubernetes import clients
 from kuryr_kubernetes.controller.drivers import neutron_vif
 
 
+CONF = oslo_cfg.CONF
 LOG = logging.getLogger(__name__)
 
 
@@ -32,26 +33,30 @@ class NestedPodVIFDriver(neutron_vif.NeutronPodVIFDriver,
 
     def _get_parent_port_by_host_ip(self, node_fixed_ip):
         os_net = clients.get_network_client()
-        node_subnet_id = oslo_cfg.CONF.pod_vif_nested.worker_nodes_subnet
-        if not node_subnet_id:
+        node_subnet_ids = oslo_cfg.CONF.pod_vif_nested.worker_nodes_subnets
+        if not node_subnet_ids:
             raise oslo_cfg.RequiredOptError(
-                'worker_nodes_subnet', oslo_cfg.OptGroup('pod_vif_nested'))
+                'worker_nodes_subnets', oslo_cfg.OptGroup('pod_vif_nested'))
 
+        fixed_ips = ['ip_address=%s' % str(node_fixed_ip)]
+        filters = {'fixed_ips': fixed_ips}
+        tags = CONF.neutron_defaults.resource_tags
+        if tags:
+            filters['tags'] = tags
         try:
-            fixed_ips = ['subnet_id=%s' % str(node_subnet_id),
-                         'ip_address=%s' % str(node_fixed_ip)]
-            ports = os_net.ports(fixed_ips=fixed_ips)
+            ports = os_net.ports(**filters)
         except os_exc.SDKException:
-            LOG.error("Parent vm port with fixed ips %s not found!",
-                      fixed_ips)
+            LOG.error("Parent VM port with fixed IPs %s not found!", fixed_ips)
             raise
 
-        try:
-            return next(ports)
-        except StopIteration:
-            LOG.error("Neutron port for vm port with fixed ips %s not found!",
-                      fixed_ips)
-            raise kl_exc.NoResourceException
+        for port in ports:
+            for fip in port.fixed_ips:
+                if fip.get('subnet_id') in node_subnet_ids:
+                    return port
+
+        LOG.error("Neutron port for VM port with fixed IPs %s not found!",
+                  fixed_ips)
+        raise kl_exc.NoResourceException()
 
     def _get_parent_port(self, pod):
         try:

--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -37,6 +37,7 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
     def __init__(self):
         self.os_net = clients.get_network_client()
         self.kubernetes = clients.get_kubernetes_client()
+        self.nodes_subnets_driver = base.NodesSubnetsDriver.get_instance()
 
     def ensure_network_policy(self, policy):
         """Create security group rules out of network policies
@@ -147,7 +148,7 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
         if CONF.octavia_defaults.enforce_sg_rules:
             default_cidrs.append(utils.get_subnet_cidr(
                 CONF.neutron_defaults.service_subnet))
-        worker_subnet_ids = CONF.pod_vif_nested.worker_nodes_subnets
+        worker_subnet_ids = self.nodes_subnets_driver.get_nodes_subnets()
         default_cidrs.extend(utils.get_subnets_cidrs(worker_subnet_ids))
 
         for cidr in default_cidrs:

--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -147,9 +147,9 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
         if CONF.octavia_defaults.enforce_sg_rules:
             default_cidrs.append(utils.get_subnet_cidr(
                 CONF.neutron_defaults.service_subnet))
-        worker_subnet_id = CONF.pod_vif_nested.worker_nodes_subnet
-        if worker_subnet_id:
-            default_cidrs.append(utils.get_subnet_cidr(worker_subnet_id))
+        worker_subnet_ids = CONF.pod_vif_nested.worker_nodes_subnets
+        default_cidrs.extend(utils.get_subnets_cidrs(worker_subnet_ids))
+
         for cidr in default_cidrs:
             ethertype = constants.IPv4
             if ipaddress.ip_network(cidr).version == constants.IP_VERSION_6:

--- a/kuryr_kubernetes/controller/drivers/node_subnets.py
+++ b/kuryr_kubernetes/controller/drivers/node_subnets.py
@@ -13,10 +13,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_log import log as logging
 
+from kuryr_kubernetes import clients
+from kuryr_kubernetes import constants
 from kuryr_kubernetes.controller.drivers import base
+from kuryr_kubernetes import exceptions
+from kuryr_kubernetes import utils
+
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
@@ -41,3 +47,79 @@ class ConfigNodesSubnets(base.NodesSubnetsDriver):
 
     def delete_node(self, node):
         return False
+
+
+class OpenShiftNodesSubnets(base.NodesSubnetsDriver):
+    """Provides list of nodes subnets based on OpenShift Machine objects."""
+
+    def __init__(self):
+        super().__init__()
+        self.subnets = set()
+
+    def _get_subnet_from_machine(self, machine):
+        networks = machine['spec'].get(
+            'providerSpec', {}).get('value', {}).get('networks')
+        if not networks:
+            LOG.warning('No `networks` in Machine `providerSpec`')
+            return None
+
+        subnets = networks[0].get('subnets')
+        if not subnets:
+            LOG.warning('No `subnets` in Machine `providerSpec.values.'
+                        'networks`.')
+            return None
+
+        primary_subnet = subnets[0]
+        if primary_subnet.get('uuid'):
+            return primary_subnet['uuid']
+        else:
+            subnet_filter = primary_subnet['filter']
+            subnet_id = utils.get_subnet_id(**subnet_filter)
+            return subnet_id
+
+    def get_nodes_subnets(self, raise_on_empty=False):
+        with lockutils.lock('kuryr-machine-add'):
+            if not self.subnets and raise_on_empty:
+                raise exceptions.ResourceNotReady(
+                    'OpenShift Machines does not exist or are not yet '
+                    'handled. Cannot determine worker nodes subnets.')
+
+            return list(self.subnets)
+
+    def add_node(self, machine):
+        subnet_id = self._get_subnet_from_machine(machine)
+        if not subnet_id:
+            LOG.warning('Could not determine subnet of Machine %s',
+                        machine['metadata']['name'])
+            return False
+
+        with lockutils.lock('kuryr-machine-add'):
+            if subnet_id not in self.subnets:
+                LOG.info('Adding subnet %s to the worker nodes subnets as '
+                         'machine %s runs in it.', subnet_id,
+                         machine['metadata']['name'])
+                self.subnets.add(subnet_id)
+                return True
+            return False
+
+    def delete_node(self, machine):
+        k8s = clients.get_kubernetes_client()
+        affected_subnet_id = self._get_subnet_from_machine(machine)
+        if not affected_subnet_id:
+            LOG.warning('Could not determine subnet of Machine %s',
+                        machine['metadata']['name'])
+            return False
+
+        machines = k8s.get(constants.OPENSHIFT_API_CRD_MACHINES)
+        for existing_machine in machines.get('items', []):
+            if affected_subnet_id == self._get_subnet_from_machine(
+                    existing_machine):
+                return False
+
+        # We know that subnet is no longer used, so we remove it.
+        LOG.info('Removing subnet %s from the worker nodes subnets',
+                 affected_subnet_id)
+        with lockutils.lock('kuryr-machine-add'):
+            self.subnets.remove(affected_subnet_id)
+
+        return True

--- a/kuryr_kubernetes/controller/drivers/node_subnets.py
+++ b/kuryr_kubernetes/controller/drivers/node_subnets.py
@@ -1,0 +1,43 @@
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+from oslo_log import log as logging
+
+from kuryr_kubernetes.controller.drivers import base
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+
+class ConfigNodesSubnets(base.NodesSubnetsDriver):
+    """Provides list of nodes subnets from configuration."""
+
+    def get_nodes_subnets(self, raise_on_empty=False):
+        node_subnet_ids = CONF.pod_vif_nested.worker_nodes_subnets
+        if not node_subnet_ids:
+            if raise_on_empty:
+                raise cfg.RequiredOptError(
+                    'worker_nodes_subnets', cfg.OptGroup('pod_vif_nested'))
+            else:
+                return []
+
+        return node_subnet_ids
+
+    def add_node(self, node):
+        return False
+
+    def delete_node(self, node):
+        return False

--- a/kuryr_kubernetes/controller/handlers/loadbalancer.py
+++ b/kuryr_kubernetes/controller/handlers/loadbalancer.py
@@ -50,8 +50,11 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
         self._drv_service_pub_ip = drv_base.ServicePubIpDriver.get_instance()
         self._drv_svc_project = drv_base.ServiceProjectDriver.get_instance()
         self._drv_sg = drv_base.ServiceSecurityGroupsDriver.get_instance()
-        self._nodes_subnets = utils.get_subnets_id_cidrs(
-            CONF.pod_vif_nested.worker_nodes_subnets)
+        self._drv_nodes_subnets = drv_base.NodesSubnetsDriver.get_instance()
+
+    def _get_nodes_subnets(self):
+        return utils.get_subnets_id_cidrs(
+            self._drv_nodes_subnets.get_nodes_subnets())
 
     def on_present(self, loadbalancer_crd):
         if self._should_ignore(loadbalancer_crd):
@@ -260,7 +263,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                     # Avoid to point to a Pod on hostNetwork
                     # that isn't the one to be added as Member.
                     if not target_ref and utils.get_subnet_by_ip(
-                            self._nodes_subnets, target_ip):
+                            self._get_nodes_subnets(),
+                            target_ip):
                         target_pod = {}
                     else:
                         target_pod = utils.get_pod_by_ip(
@@ -356,7 +360,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
             if target_pod:
                 subnet_id = self._get_pod_subnet(target_pod, target_ip)
             else:
-                subnet = utils.get_subnet_by_ip(self._nodes_subnets, target_ip)
+                subnet = utils.get_subnet_by_ip(
+                    self._drv_nodes_subnets.get_nodes_subnets(), target_ip)
                 if subnet:
                     subnet_id = subnet[0]
         else:
@@ -378,13 +383,13 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
             # NOTE(ltomasbo): We are assuming that if IP is not on the
             # pod subnet it's because the member is using hostNetworking. In
             # this case we look for the IP in worker_nodes_subnets.
-            subnet = utils.get_subnet_by_ip(self._nodes_subnets, ip)
+            subnet = utils.get_subnet_by_ip(self._get_nodes_subnets(), ip)
             if subnet:
                 return subnet[0]
             else:
                 # This shouldn't ever happen but let's return just the first
                 # worker_nodes_subnet id.
-                return self._nodes_subnets[0][0]
+                return self._get_nodes_subnets()[0][0]
 
     def _get_port_in_pool(self, pool, loadbalancer_crd):
 

--- a/kuryr_kubernetes/controller/handlers/machine.py
+++ b/kuryr_kubernetes/controller/handlers/machine.py
@@ -1,0 +1,67 @@
+# Copyright 2020 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+
+from oslo_log import log as logging
+
+from kuryr_kubernetes import clients
+from kuryr_kubernetes import constants
+from kuryr_kubernetes.controller.drivers import base as drivers
+from kuryr_kubernetes import exceptions
+from kuryr_kubernetes.handlers import k8s_base
+
+LOG = logging.getLogger(__name__)
+
+
+class MachineHandler(k8s_base.ResourceEventHandler):
+    """MachineHandler gathers info about OpenShift nodes needed by Kuryr.
+
+    At the moment that's the subnets of all the worker nodes.
+    """
+    OBJECT_KIND = constants.OPENSHIFT_OBJ_MACHINE
+    OBJECT_WATCH_PATH = constants.OPENSHIFT_API_CRD_MACHINES
+
+    def __init__(self):
+        super(MachineHandler, self).__init__()
+        self.node_subnets_driver = drivers.NodesSubnetsDriver.get_instance()
+
+    def _bump_nps(self):
+        """Bump NetworkPolicy objects to have the SG rules recalculated."""
+        k8s = clients.get_kubernetes_client()
+        # NOTE(dulek): Listing KuryrNetworkPolicies instead of NetworkPolicies,
+        #              as we only care about NPs already handled.
+        knps = k8s.get(constants.K8S_API_CRD_KURYRNETWORKPOLICIES)
+        for knp in knps.get('items', []):
+            try:
+                k8s.annotate(
+                    knp['metadata']['annotations']['networkPolicyLink'],
+                    {constants.K8S_ANNOTATION_POLICY: str(uuid.uuid4())})
+            except exceptions.K8sResourceNotFound:
+                # Had to be deleted in the meanwhile.
+                pass
+
+    def on_present(self, machine):
+        effect = self.node_subnets_driver.add_node(machine)
+        if effect:
+            # If the change was meaningful we need to make sure all the NPs
+            # are recalculated to get the new SG rules added.
+            self._bump_nps()
+
+    def on_deleted(self, machine):
+        effect = self.node_subnets_driver.delete_node(machine)
+        if effect:
+            # If the change was meaningful we need to make sure all the NPs
+            # are recalculated to get the old SG rule deleted.
+            self._bump_nps()

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_nested_vif.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_nested_vif.py
@@ -16,6 +16,7 @@ from kuryr.lib import exceptions as kl_exc
 from oslo_config import cfg as oslo_cfg
 
 from kuryr_kubernetes.controller.drivers import nested_vif
+from kuryr_kubernetes.controller.drivers import node_subnets
 from kuryr_kubernetes.tests import base as test_base
 from kuryr_kubernetes.tests.unit import kuryr_fixtures as k_fix
 
@@ -42,7 +43,8 @@ class TestNestedPodVIFDriver(test_base.TestCase):
 
     def test_get_parent_port_by_host_ip(self):
         cls = nested_vif.NestedPodVIFDriver
-        m_driver = mock.Mock(spec=cls)
+        m_driver = mock.Mock(
+            spec=cls, nodes_subnets_driver=node_subnets.ConfigNodesSubnets())
         os_net = self.useFixture(k_fix.MockNetworkClient()).client
 
         node_subnet_id1 = 'node_subnet_id1'
@@ -66,7 +68,8 @@ class TestNestedPodVIFDriver(test_base.TestCase):
 
     def test_get_parent_port_by_host_ip_multiple(self):
         cls = nested_vif.NestedPodVIFDriver
-        m_driver = mock.Mock(spec=cls)
+        m_driver = mock.Mock(
+            spec=cls, nodes_subnets_driver=node_subnets.ConfigNodesSubnets())
         os_net = self.useFixture(k_fix.MockNetworkClient()).client
 
         node_subnet_id1 = 'node_subnet_id1'
@@ -91,7 +94,8 @@ class TestNestedPodVIFDriver(test_base.TestCase):
 
     def test_get_parent_port_by_host_ip_subnet_id_not_configured(self):
         cls = nested_vif.NestedPodVIFDriver
-        m_driver = mock.Mock(spec=cls)
+        m_driver = mock.Mock(
+            spec=cls, nodes_subnets_driver=node_subnets.ConfigNodesSubnets())
         self.useFixture(k_fix.MockNetworkClient()).client
         oslo_cfg.CONF.set_override('worker_nodes_subnets',
                                    '',
@@ -103,7 +107,8 @@ class TestNestedPodVIFDriver(test_base.TestCase):
 
     def test_get_parent_port_by_host_ip_trunk_not_found(self):
         cls = nested_vif.NestedPodVIFDriver
-        m_driver = mock.Mock(spec=cls)
+        m_driver = mock.Mock(
+            spec=cls, nodes_subnets_driver=node_subnets.ConfigNodesSubnets())
         os_net = self.useFixture(k_fix.MockNetworkClient()).client
 
         node_subnet_id = 'node_subnet_id'

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_node_subnets.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_node_subnets.py
@@ -1,0 +1,61 @@
+# Copyright 2020 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+
+from kuryr_kubernetes.controller.drivers import node_subnets
+from kuryr_kubernetes.tests import base as test_base
+
+
+class TestConfigNodesSubnetsDriver(test_base.TestCase):
+
+    def test_get_nodes_subnets(self):
+        subnets = ['subnet1', 'subnet2']
+        cfg.CONF.set_override('worker_nodes_subnets', subnets,
+                              group='pod_vif_nested')
+        driver = node_subnets.ConfigNodesSubnets()
+
+        self.assertEqual(subnets, driver.get_nodes_subnets())
+
+    def test_get_nodes_subnets_alias(self):
+        subnet = 'subnet1'
+        cfg.CONF.set_override('worker_nodes_subnet', subnet,
+                              group='pod_vif_nested')
+        driver = node_subnets.ConfigNodesSubnets()
+
+        self.assertEqual([subnet], driver.get_nodes_subnets())
+
+    def test_get_project_not_set_raise(self):
+        cfg.CONF.set_override('worker_nodes_subnets', None,
+                              group='pod_vif_nested')
+        driver = node_subnets.ConfigNodesSubnets()
+
+        self.assertRaises(cfg.RequiredOptError, driver.get_nodes_subnets,
+                          raise_on_empty=True)
+
+    def test_get_project_not_set(self):
+        cfg.CONF.set_override('worker_nodes_subnets', None,
+                              group='pod_vif_nested')
+        driver = node_subnets.ConfigNodesSubnets()
+
+        self.assertEqual([], driver.get_nodes_subnets())
+
+    def test_add_node(self):
+        driver = node_subnets.ConfigNodesSubnets()
+        self.assertFalse(driver.add_node('node'))
+
+    def test_delete_node(self):
+        driver = node_subnets.ConfigNodesSubnets()
+        self.assertFalse(driver.delete_node('node'))

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_node_subnets.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_node_subnets.py
@@ -13,9 +13,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
+
 from oslo_config import cfg
 
 from kuryr_kubernetes.controller.drivers import node_subnets
+from kuryr_kubernetes import exceptions
 from kuryr_kubernetes.tests import base as test_base
 
 
@@ -59,3 +62,137 @@ class TestConfigNodesSubnetsDriver(test_base.TestCase):
     def test_delete_node(self):
         driver = node_subnets.ConfigNodesSubnets()
         self.assertFalse(driver.delete_node('node'))
+
+
+class TestOpenShiftNodesSubnetsDriver(test_base.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.machine = {
+            "apiVersion": "machine.openshift.io/v1beta1",
+            "kind": "Machine",
+            "metadata": {
+                "name": "foo-tv22d-master-2",
+                "namespace": "openshift-machine-api",
+            },
+            "spec": {
+                "metadata": {},
+                "providerSpec": {
+                    "value": {
+                        "cloudName": "openstack",
+                        "cloudsSecret": {
+                            "name": "openstack-cloud-credentials",
+                            "namespace": "openshift-machine-api"
+                        },
+                        "kind": "OpenstackProviderSpec",
+                        "networks": [
+                            {
+                                "filter": {},
+                                "subnets": [{
+                                    "filter": {
+                                        "name": "foo-tv22d-nodes",
+                                        "tags": "openshiftClusterID=foo-tv22d"
+                                    }}
+                                ]
+                            }
+                        ],
+                    }
+                }
+            },
+            "status": {}
+        }
+
+    def test_get_nodes_subnets(self):
+        subnets = ['subnet1', 'subnet2']
+        driver = node_subnets.OpenShiftNodesSubnets()
+        for subnet in subnets:
+            driver.subnets.add(subnet)
+        self.assertCountEqual(subnets, driver.get_nodes_subnets())
+
+    def test_get_nodes_subnets_not_raise(self):
+        driver = node_subnets.OpenShiftNodesSubnets()
+        self.assertEqual([], driver.get_nodes_subnets())
+
+    def test_get_nodes_subnets_raise(self):
+        driver = node_subnets.OpenShiftNodesSubnets()
+        self.assertRaises(exceptions.ResourceNotReady,
+                          driver.get_nodes_subnets, raise_on_empty=True)
+
+    @mock.patch('kuryr_kubernetes.utils.get_subnet_id')
+    def test_add_node(self, m_get_subnet_id):
+        driver = node_subnets.OpenShiftNodesSubnets()
+        m_get_subnet_id.return_value = 'foobar'
+        self.assertTrue(driver.add_node(self.machine))
+        m_get_subnet_id.assert_called_once_with(
+            name='foo-tv22d-nodes', tags='openshiftClusterID=foo-tv22d')
+        self.assertEqual(['foobar'], driver.get_nodes_subnets())
+
+    @mock.patch('kuryr_kubernetes.utils.get_subnet_id')
+    def test_add_node_exists(self, m_get_subnet_id):
+        driver = node_subnets.OpenShiftNodesSubnets()
+        m_get_subnet_id.return_value = 'foobar'
+        driver.subnets.add('foobar')
+        self.assertFalse(driver.add_node(self.machine))
+        m_get_subnet_id.assert_called_once_with(
+            name='foo-tv22d-nodes', tags='openshiftClusterID=foo-tv22d')
+        self.assertEqual(['foobar'], driver.get_nodes_subnets())
+
+    @mock.patch('kuryr_kubernetes.utils.get_subnet_id')
+    def test_add_node_uuid(self, m_get_subnet_id):
+        driver = node_subnets.OpenShiftNodesSubnets()
+        net = self.machine['spec']['providerSpec']['value']['networks'][0]
+        del net['subnets'][0]['filter']
+        net['subnets'][0]['uuid'] = 'barfoo'
+        self.assertTrue(driver.add_node(self.machine))
+        m_get_subnet_id.assert_not_called()
+        self.assertEqual(['barfoo'], driver.get_nodes_subnets())
+
+    @mock.patch('kuryr_kubernetes.utils.get_subnet_id')
+    def test_add_node_cannot(self, m_get_subnet_id):
+        driver = node_subnets.OpenShiftNodesSubnets()
+        net = self.machine['spec']['providerSpec']['value']['networks'][0]
+        del net['subnets']
+        self.assertFalse(driver.add_node(self.machine))
+        m_get_subnet_id.assert_not_called()
+        self.assertEqual([], driver.get_nodes_subnets())
+
+    @mock.patch('kuryr_kubernetes.utils.get_subnet_id')
+    @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
+    def test_delete_node_cannot(self, m_get_k8s, m_get_subnet_id):
+        m_k8s = mock.Mock()
+        m_get_k8s.return_value = m_k8s
+        driver = node_subnets.OpenShiftNodesSubnets()
+        net = self.machine['spec']['providerSpec']['value']['networks'][0]
+        del net['subnets']
+        self.assertFalse(driver.delete_node(self.machine))
+        m_get_subnet_id.assert_not_called()
+        self.assertEqual([], driver.get_nodes_subnets())
+
+    @mock.patch('kuryr_kubernetes.utils.get_subnet_id')
+    @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
+    def test_delete_node(self,  m_get_k8s, m_get_subnet_id):
+        m_k8s = mock.Mock()
+        m_get_k8s.return_value = m_k8s
+        m_k8s.get.return_value = {'items': []}
+
+        driver = node_subnets.OpenShiftNodesSubnets()
+        driver.subnets.add('foobar')
+        m_get_subnet_id.return_value = 'foobar'
+        self.assertTrue(driver.delete_node(self.machine))
+        m_get_subnet_id.assert_called_once_with(
+            name='foo-tv22d-nodes', tags='openshiftClusterID=foo-tv22d')
+        self.assertEqual([], driver.get_nodes_subnets())
+
+    @mock.patch('kuryr_kubernetes.utils.get_subnet_id')
+    @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
+    def test_delete_node_still_exists(self,  m_get_k8s, m_get_subnet_id):
+        m_k8s = mock.Mock()
+        m_get_k8s.return_value = m_k8s
+        m_k8s.get.return_value = {'items': [self.machine]}
+
+        driver = node_subnets.OpenShiftNodesSubnets()
+        driver.subnets.add('foobar')
+        m_get_subnet_id.return_value = 'foobar'
+        self.assertFalse(driver.delete_node(self.machine))
+        m_get_subnet_id.assert_called_with(
+            name='foo-tv22d-nodes', tags='openshiftClusterID=foo-tv22d')
+        self.assertEqual(['foobar'], driver.get_nodes_subnets())

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_loadbalancer.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_loadbalancer.py
@@ -208,9 +208,12 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
                 '.PodProjectDriver.get_instance')
     @mock.patch('kuryr_kubernetes.controller.drivers.base'
                 '.LBaaSDriver.get_instance')
-    def test_init(self, m_get_drv_lbaas, m_get_drv_project,
-                  m_get_drv_subnets, m_get_drv_service_pub_ip, m_cfg,
-                  m_get_svc_sg_drv, m_get_svc_drv_project, m_get_cidr):
+    @mock.patch('kuryr_kubernetes.controller.drivers.base'
+                '.NodesSubnetsDriver.get_instance')
+    def test_init(self, m_get_drv_node_subnets, m_get_drv_lbaas,
+                  m_get_drv_project, m_get_drv_subnets,
+                  m_get_drv_service_pub_ip, m_cfg, m_get_svc_sg_drv,
+                  m_get_svc_drv_project, m_get_cidr):
         m_get_drv_lbaas.return_value = mock.sentinel.drv_lbaas
         m_get_drv_project.return_value = mock.sentinel.drv_project
         m_get_drv_subnets.return_value = mock.sentinel.drv_subnets
@@ -218,12 +221,15 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
         m_get_drv_service_pub_ip.return_value = mock.sentinel.drv_lb_ip
         m_get_svc_drv_project.return_value = mock.sentinel.drv_svc_project
         m_get_svc_sg_drv.return_value = mock.sentinel.drv_sg
+        m_get_drv_node_subnets.return_value = mock.sentinel.drv_node_subnets
         handler = h_lb.KuryrLoadBalancerHandler()
 
         self.assertEqual(mock.sentinel.drv_lbaas, handler._drv_lbaas)
         self.assertEqual(mock.sentinel.drv_project, handler._drv_pod_project)
         self.assertEqual(mock.sentinel.drv_subnets, handler._drv_pod_subnets)
         self.assertEqual(mock.sentinel.drv_lb_ip, handler._drv_service_pub_ip)
+        self.assertEqual(mock.sentinel.drv_node_subnets,
+                         handler._drv_nodes_subnets)
 
     @mock.patch('kuryr_kubernetes.utils.get_subnet_cidr')
     @mock.patch('kuryr_kubernetes.controller.drivers.base.'
@@ -239,9 +245,12 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
                 '.PodProjectDriver.get_instance')
     @mock.patch('kuryr_kubernetes.controller.drivers.base'
                 '.LBaaSDriver.get_instance')
-    def test_init_provider_ovn(self, m_get_drv_lbaas, m_get_drv_project,
-                               m_get_drv_subnets, m_get_drv_service_pub_ip,
-                               m_cfg, m_get_svc_sg_drv, m_get_svc_drv_project,
+    @mock.patch('kuryr_kubernetes.controller.drivers.base'
+                '.NodesSubnetsDriver.get_instance')
+    def test_init_provider_ovn(self, m_get_drv_node_subnets, m_get_drv_lbaas,
+                               m_get_drv_project, m_get_drv_subnets,
+                               m_get_drv_service_pub_ip, m_cfg,
+                               m_get_svc_sg_drv, m_get_svc_drv_project,
                                m_get_cidr):
         m_get_cidr.return_value = '10.0.0.128/26'
         m_get_drv_lbaas.return_value = mock.sentinel.drv_lbaas
@@ -250,12 +259,15 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
         m_get_drv_service_pub_ip.return_value = mock.sentinel.drv_lb_ip
         m_get_svc_drv_project.return_value = mock.sentinel.drv_svc_project
         m_get_svc_sg_drv.return_value = mock.sentinel.drv_sg
+        m_get_drv_node_subnets.return_value = mock.sentinel.drv_node_subnets
         handler = h_lb .KuryrLoadBalancerHandler()
 
         self.assertEqual(mock.sentinel.drv_lbaas, handler._drv_lbaas)
         self.assertEqual(mock.sentinel.drv_project, handler._drv_pod_project)
         self.assertEqual(mock.sentinel.drv_subnets, handler._drv_pod_subnets)
         self.assertEqual(mock.sentinel.drv_lb_ip, handler._drv_service_pub_ip)
+        self.assertEqual(mock.sentinel.drv_node_subnets,
+                         handler._drv_nodes_subnets)
 
     def test_on_present(self):
         m_drv_service_pub_ip = mock.Mock()
@@ -440,6 +452,8 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
                 '.PodProjectDriver.get_instance')
     @mock.patch('kuryr_kubernetes.controller.drivers.base'
                 '.LBaaSDriver.get_instance')
+    @mock.patch('kuryr_kubernetes.controller.drivers.base'
+                '.NodesSubnetsDriver.get_instance', mock.Mock())
     def test_sync_lbaas_members(self, m_get_drv_lbaas, m_get_drv_project,
                                 m_get_drv_subnets, m_k8s, m_svc_project_drv,
                                 m_svc_sg_drv, m_get_cidr):
@@ -473,6 +487,8 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
                 '.PodProjectDriver.get_instance')
     @mock.patch('kuryr_kubernetes.controller.drivers.base'
                 '.LBaaSDriver.get_instance')
+    @mock.patch('kuryr_kubernetes.controller.drivers.base'
+                '.NodesSubnetsDriver.get_instance', mock.Mock())
     def test_sync_lbaas_members_udp(self, m_get_drv_lbaas,
                                     m_get_drv_project, m_get_drv_subnets,
                                     m_k8s, m_svc_project_drv, m_svc_sg_drv,
@@ -508,6 +524,8 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
                 '.PodProjectDriver.get_instance')
     @mock.patch('kuryr_kubernetes.controller.drivers.base'
                 '.LBaaSDriver.get_instance')
+    @mock.patch('kuryr_kubernetes.controller.drivers.base'
+                '.NodesSubnetsDriver.get_instance', mock.Mock())
     def test_sync_lbaas_members_svc_listener_port_edit(
             self, m_get_drv_lbaas, m_get_drv_project, m_get_drv_subnets,
             m_k8s, m_svc_project_drv, m_svc_sg_drv, m_get_cidr):
@@ -548,6 +566,8 @@ class TestKuryrLoadBalancerHandler(test_base.TestCase):
                 '.PodProjectDriver.get_instance')
     @mock.patch('kuryr_kubernetes.controller.drivers.base'
                 '.LBaaSDriver.get_instance')
+    @mock.patch('kuryr_kubernetes.controller.drivers.base'
+                '.NodesSubnetsDriver.get_instance', mock.Mock())
     def test_add_new_members_udp(self, m_get_drv_lbaas,
                                  m_get_drv_project, m_get_drv_subnets,
                                  m_k8s, m_svc_project_drv,

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_loadbalancer.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_loadbalancer.py
@@ -191,8 +191,9 @@ class FakeLBaaSDriver(drv_base.LBaaSDriver):
         }
 
 
+@mock.patch('kuryr_kubernetes.utils.get_subnets_id_cidrs',
+            mock.Mock(return_value=[('id', 'cidr')]))
 class TestKuryrLoadBalancerHandler(test_base.TestCase):
-
     @mock.patch('kuryr_kubernetes.utils.get_subnet_cidr')
     @mock.patch('kuryr_kubernetes.controller.drivers.base.'
                 'ServiceProjectDriver.get_instance')

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_machine.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_machine.py
@@ -1,0 +1,84 @@
+# Copyright 2020 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from kuryr_kubernetes import constants
+from kuryr_kubernetes.controller.handlers import machine
+from kuryr_kubernetes import exceptions
+from kuryr_kubernetes.tests import base as test_base
+
+
+class TestKuryrMachineHandler(test_base.TestCase):
+    @mock.patch(
+        'kuryr_kubernetes.controller.drivers.base.NodesSubnetsDriver.'
+        'get_instance')
+    def setUp(self, m_get_instance):
+        super(TestKuryrMachineHandler, self).setUp()
+        self.driver = mock.Mock()
+        m_get_instance.return_value = self.driver
+        self.handler = machine.MachineHandler()
+
+    def test_on_present(self):
+        self.handler._bump_nps = mock.Mock()
+        self.driver.add_node.return_value = False
+        self.handler.on_present(mock.sentinel.machine)
+        self.driver.add_node.assert_called_once_with(mock.sentinel.machine)
+        self.handler._bump_nps.assert_not_called()
+
+    def test_on_present_new(self):
+        self.handler._bump_nps = mock.Mock()
+        self.driver.add_node.return_value = True
+        self.handler.on_present(mock.sentinel.machine)
+        self.driver.add_node.assert_called_once_with(mock.sentinel.machine)
+        self.handler._bump_nps.assert_called_once()
+
+    def test_on_deleted(self):
+        self.handler._bump_nps = mock.Mock()
+        self.driver.delete_node.return_value = False
+        self.handler.on_deleted(mock.sentinel.machine)
+        self.driver.delete_node.assert_called_once_with(mock.sentinel.machine)
+        self.handler._bump_nps.assert_not_called()
+
+    def test_on_deleted_gone(self):
+        self.handler._bump_nps = mock.Mock()
+        self.driver.delete_node.return_value = True
+        self.handler.on_deleted(mock.sentinel.machine)
+        self.driver.delete_node.assert_called_once_with(mock.sentinel.machine)
+        self.handler._bump_nps.assert_called_once()
+
+    @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
+    def test_bump_nps(self, get_client):
+        m_k8s = mock.Mock()
+        get_client.return_value = m_k8s
+        m_k8s.get.return_value = {
+            'items': [
+                {'metadata': {'annotations': {
+                    'networkPolicyLink': mock.sentinel.link1}}},
+                {'metadata': {'annotations': {
+                    'networkPolicyLink': mock.sentinel.link2}}},
+                {'metadata': {'annotations': {
+                    'networkPolicyLink': mock.sentinel.link3}}},
+            ]
+        }
+        m_k8s.annotate.side_effect = (
+            None, exceptions.K8sResourceNotFound('NP'), None)
+        self.handler._bump_nps()
+        m_k8s.get.assert_called_once_with(
+            constants.K8S_API_CRD_KURYRNETWORKPOLICIES)
+        m_k8s.annotate.assert_has_calls([
+            mock.call(mock.sentinel.link1, mock.ANY),
+            mock.call(mock.sentinel.link2, mock.ANY),
+            mock.call(mock.sentinel.link3, mock.ANY),
+        ])

--- a/kuryr_kubernetes/tests/unit/test_utils.py
+++ b/kuryr_kubernetes/tests/unit/test_utils.py
@@ -447,3 +447,25 @@ class TestUtils(test_base.TestCase):
         res = {'metadata': {'selfLink': '/foo'}}
 
         self.assertEqual(utils.get_res_link(res), '/foo')
+
+    @mock.patch('kuryr_kubernetes.clients.get_network_client')
+    def test_get_subnet_id(self, m_get_net):
+        m_net = mock.Mock()
+        m_get_net.return_value = m_net
+        subnets = (mock.Mock(id=mock.sentinel.subnet1),
+                   mock.Mock(id=mock.sentinel.subnet2))
+        m_net.subnets.return_value = iter(subnets)
+        filters = {'name': 'foo', 'tags': 'bar'}
+        sub = utils.get_subnet_id(**filters)
+        m_net.subnets.assert_called_with(**filters)
+        self.assertEqual(mock.sentinel.subnet1, sub)
+
+    @mock.patch('kuryr_kubernetes.clients.get_network_client')
+    def test_get_subnet_not_found(self, m_get_net):
+        m_net = mock.Mock()
+        m_get_net.return_value = m_net
+        m_net.subnets.return_value = iter(())
+        filters = {'name': 'foo', 'tags': 'bar'}
+        sub = utils.get_subnet_id(**filters)
+        m_net.subnets.assert_called_with(**filters)
+        self.assertIsNone(sub)

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -84,7 +84,8 @@ RESOURCE_MAP = {'Endpoints': 'endpoints',
                 'NetworkPolicy': 'networkpolicies',
                 'Node': 'nodes',
                 'Pod': 'pods',
-                'Service': 'services'}
+                'Service': 'services',
+                'Machine': 'machines'}
 API_RE = re.compile(r'v\d+')
 
 
@@ -296,6 +297,16 @@ def get_subnet_cidr(subnet_id):
         LOG.exception("Subnet %s CIDR not found!", subnet_id)
         raise
     return subnet_obj.cidr
+
+
+def get_subnet_id(**filters):
+    os_net = clients.get_network_client()
+    subnets = os_net.subnets(**filters)
+
+    try:
+        return next(subnets).id
+    except StopIteration:
+        return None
 
 
 @MEMOIZE

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -299,6 +299,24 @@ def get_subnet_cidr(subnet_id):
 
 
 @MEMOIZE
+def get_subnets_id_cidrs(subnet_ids):
+    os_net = clients.get_network_client()
+    subnets = os_net.subnets()
+    cidrs = [(subnet.id, subnet.cidr) for subnet in subnets
+             if subnet.id in subnet_ids]
+    if len(cidrs) != len(subnet_ids):
+        existing = {subnet.id for subnet in subnets}
+        missing = set(subnet_ids) - existing
+        LOG.exception("CIDRs of subnets %s not found!", missing)
+        raise os_exc.ResourceNotFound()
+    return cidrs
+
+
+def get_subnets_cidrs(subnet_ids):
+    return [x[1] for x in get_subnets_id_cidrs(subnet_ids)]
+
+
+@MEMOIZE
 def get_subnetpool_version(subnetpool_id):
     os_net = clients.get_network_client()
     try:
@@ -573,7 +591,10 @@ def get_current_endpoints_target(ep, port, spec_ports, ep_name):
             spec_ports.get(port.get('name')))
 
 
-def is_ip_on_subnet(nodes_subnet, target_ip):
-    return (nodes_subnet and
-            (ipaddress.ip_address(target_ip) in
-                ipaddress.ip_network(nodes_subnet)))
+def get_subnet_by_ip(nodes_subnets, target_ip):
+    ip = ipaddress.ip_address(target_ip)
+    for nodes_subnet in nodes_subnets:
+        if ip in ipaddress.ip_network(nodes_subnet[1]):
+            return nodes_subnet
+
+    return None

--- a/releasenotes/notes/deprecate-worker-nodes-subnet-e452c84df5b5ed5c.yaml
+++ b/releasenotes/notes/deprecate-worker-nodes-subnet-e452c84df5b5ed5c.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Kuryr will now support nested mode with nodes VMs running in multiple
+    subnets. In order to use that functionality a new option
+    `[pod_vif_nested]worker_nodes_subnets` is introduced and will accept a list
+    of subnet IDs.
+deprecations:
+  - |
+    Option `[pod_vif_nested]worker_nodes_subnet` is deprecated in favor of
+    `[pod_vif_nested]worker_nodes_subnets` that accepts a list instead of a
+    single ID.

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,9 @@ kuryr_kubernetes.controller.drivers.vif_pool =
     nested = kuryr_kubernetes.controller.drivers.vif_pool:NestedVIFPool
     multi_pool = kuryr_kubernetes.controller.drivers.vif_pool:MultiVIFPool
 
+kuryr_kubernetes.controller.drivers.nodes_subnets =
+    config = kuryr_kubernetes.controller.drivers.node_subnets:ConfigNodesSubnets
+
 kuryr_kubernetes.controller.handlers =
     vif = kuryr_kubernetes.controller.handlers.vif:VIFHandler
     service = kuryr_kubernetes.controller.handlers.lbaas:ServiceHandler

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,6 +100,7 @@ kuryr_kubernetes.controller.drivers.vif_pool =
 
 kuryr_kubernetes.controller.drivers.nodes_subnets =
     config = kuryr_kubernetes.controller.drivers.node_subnets:ConfigNodesSubnets
+    openshift = kuryr_kubernetes.controller.drivers.node_subnets:OpenShiftNodesSubnets
 
 kuryr_kubernetes.controller.handlers =
     vif = kuryr_kubernetes.controller.handlers.vif:VIFHandler
@@ -114,6 +115,7 @@ kuryr_kubernetes.controller.handlers =
     kuryrnetwork_population = kuryr_kubernetes.controller.handlers.kuryrnetwork_population:KuryrNetworkPopulationHandler
     test_handler = kuryr_kubernetes.tests.unit.controller.handlers.test_fake_handler:TestHandler
     kuryrport = kuryr_kubernetes.controller.handlers.kuryrport:KuryrPortHandler
+    openshift_machine = kuryr_kubernetes.controller.handlers.machine:MachineHandler
 
 kuryr_kubernetes.controller.drivers.multi_vif =
     noop = kuryr_kubernetes.controller.drivers.multi_vif:NoopMultiVIFDriver

--- a/tools/generate_k8s_resource_definitions.sh
+++ b/tools/generate_k8s_resource_definitions.sh
@@ -34,7 +34,7 @@ if [ -z $CONF_PATH ]; then
     pod_subnet_id=${KURYR_K8S_POD_SUBNET_ID}
     pod_sg=${KURYR_K8S_POD_SG}
     service_subnet_id=${KURYR_K8S_SERVICE_SUBNET_ID}
-    worker_nodes_subnet=${KURYR_K8S_WORKER_NODES_SUBNET}
+    worker_nodes_subnets=${KURYR_K8S_WORKER_NODES_SUBNETS:-${KURYR_K8S_WORKER_NODES_SUBNET}}
     binding_driver=${KURYR_K8S_BINDING_DRIVER:-kuryr.lib.binding.drivers.vlan}
     binding_iface=${KURYR_K8S_BINDING_IFACE:-eth0}
     pod_subnet_pool=${KURYR_NEUTRON_DEFAULT_SUBNETPOOL_ID}
@@ -86,7 +86,7 @@ EOF
     if [ ! -z $binding_driver ]; then
         cat >> $CONF_PATH << EOF
 [pod_vif_nested]
-worker_nodes_subnet = $worker_nodes_subnet
+worker_nodes_subnets = $worker_nodes_subnets
 [binding]
 driver = $binding_driver
 link_iface = $binding_iface


### PR DESCRIPTION
This set of patches catches Kuryr up with recently introduced ShiftOnStack ability to run additional nodes on separate subnets. In order to support it we needed to make sure `worker_nodes_subnets` option that accepts a list is introduced, as well as make sure we're actually able to listen for changes in OpenShift `Machine` objects in order to get the current set of `worker_nodes_subnets` in the most reliable way.