### PR TITLE
Bug 1919398: Open all protocols on allow-all policies

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -283,7 +283,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
             for container_port, pods in matched_pods.items():
                 sg_rule = driver_utils.create_security_group_rule_body(
                     direction, container_port,
-                    protocol=port.get('protocol'),
+                    # Pod's spec.containers[].port.protocol defaults to TCP
+                    protocol=port.get('protocol', 'TCP'),
                     cidr=cidr, pods=pods)
                 if sg_rule not in crd_rules:
                     crd_rules.append(sg_rule)
@@ -291,7 +292,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     self._create_svc_egress_sg_rule(
                         policy_namespace, crd_rules,
                         resource=resource, port=container_port,
-                        protocol=port.get('protocol'))
+                        # Pod's spec.containers[].port.protocol defaults to TCP
+                        protocol=port.get('protocol', 'TCP'))
 
     def _create_sg_rule_body_on_text_port(self, direction, port,
                                           resources, crd_rules, pod_selector,
@@ -345,7 +347,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 for ethertype in (constants.IPv4, constants.IPv6):
                     sg_rule = driver_utils.create_security_group_rule_body(
                         direction, container_port,
-                        protocol=port.get('protocol'),
+                        # Pod's spec.containers[].port.protocol defaults to TCP
+                        protocol=port.get('protocol', 'TCP'),
                         ethertype=ethertype,
                         pods=pods)
                     crd_rules.append(sg_rule)
@@ -363,7 +366,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
             sg_rule = (
                 driver_utils.create_security_group_rule_body(
                     direction, port.get('port'),
-                    protocol=port.get('protocol'),
+                    # NP's ports[].protocol defaults to TCP
+                    protocol=port.get('protocol', 'TCP'),
                     cidr=cidr,
                     namespace=ns))
             sg_rule_body_list.append(sg_rule)
@@ -371,7 +375,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 self._create_svc_egress_sg_rule(
                     policy_namespace, sg_rule_body_list,
                     resource=resource, port=port.get('port'),
-                    protocol=port.get('protocol'))
+                    # NP's ports[].protocol defaults to TCP
+                    protocol=port.get('protocol', 'TCP'))
 
     def _create_all_pods_sg_rules(self, port, direction,
                                   sg_rule_body_list, pod_selector,
@@ -388,7 +393,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     driver_utils.create_security_group_rule_body(
                         direction, port.get('port'),
                         ethertype=ethertype,
-                        protocol=port.get('protocol')))
+                        # NP's ports[].protocol defaults to TCP
+                        protocol=port.get('protocol', 'TCP')))
                 sg_rule_body_list.append(sg_rule)
 
     def _create_default_sg_rule(self, direction, sg_rule_body_list):
@@ -505,8 +511,6 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                         continue
                     rule = driver_utils.create_security_group_rule_body(
                         direction,
-                        port_range_min=1,
-                        port_range_max=65535,
                         cidr=cidr,
                         namespace=namespace)
                     sg_rule_body_list.append(rule)
@@ -518,8 +522,6 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     for ethertype in (constants.IPv4, constants.IPv6):
                         rule = driver_utils.create_security_group_rule_body(
                             direction,
-                            port_range_min=1,
-                            port_range_max=65535,
                             ethertype=ethertype)
                         sg_rule_body_list.append(rule)
             else:

--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -580,7 +580,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 if ns_name != resource['metadata']['name']:
                     continue
             cluster_ip = service['spec'].get('clusterIP')
-            if not cluster_ip:
+            if not cluster_ip or cluster_ip == 'None':
+                # Headless services has 'None' as clusterIP.
                 continue
             rule = driver_utils.create_security_group_rule_body(
                 'egress', port, protocol=protocol,

--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -261,13 +261,9 @@ def create_security_group_rule_body(
         ethertype='IPv4', cidr=None,
         description="Kuryr-Kubernetes NetPolicy SG rule", namespace=None,
         pods=None):
-    if not port_range_min:
-        port_range_min = 1
-        port_range_max = 65535
-    elif not port_range_max:
+
+    if port_range_min and not port_range_max:
         port_range_max = port_range_min
-    if not protocol:
-        protocol = 'TCP'
 
     if cidr and netaddr.IPNetwork(cidr).version == 6:
         ethertype = 'IPv6'
@@ -277,11 +273,13 @@ def create_security_group_rule_body(
             'ethertype': ethertype,
             'description': description,
             'direction': direction,
-            'protocol': protocol.lower(),
-            'port_range_min': port_range_min,
-            'port_range_max': port_range_max,
         }
     }
+    if port_range_min and port_range_max:
+        security_group_rule_body['sgRule']['port_range_min'] = port_range_min
+        security_group_rule_body['sgRule']['port_range_max'] = port_range_max
+    if protocol:
+        security_group_rule_body['sgRule']['protocol'] = protocol.lower()
     if cidr:
         security_group_rule_body['sgRule']['remote_ip_prefix'] = cidr
     if namespace:

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy.py
@@ -341,12 +341,8 @@ class TestNetworkPolicyDriver(test_base.TestCase):
         self._driver.parse_network_policy_rules(policy)
         m_get_namespaces.assert_called()
         m_get_resource_details.assert_called()
-        calls = [mock.call('ingress', port_range_min=1,
-                           port_range_max=65535, cidr=subnet_cidr,
-                           namespace=namespace),
-                 mock.call('egress', port_range_min=1,
-                           port_range_max=65535, cidr=subnet_cidr,
-                           namespace=namespace)]
+        calls = [mock.call('ingress', cidr=subnet_cidr, namespace=namespace),
+                 mock.call('egress', cidr=subnet_cidr, namespace=namespace)]
         m_create.assert_has_calls(calls)
 
     @mock.patch.object(network_policy.NetworkPolicyDriver, 'namespaced_pods')


### PR DESCRIPTION
We have troubles with policies like these:

```
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: networkpolicy-example
spec:
  podSelector: {}
  policyTypes:
  - Egress
  - Ingress
  ingress:
  - from:
    - podSelector: {}
  egress:
  - to:
    - ipBlock:
        cidr: 0.0.0.0/0
```

First of all we have troubles with headless services handling in code doing allow-all in NP and this PR solves that by ignoring them there. Secondly for allow-all we only open TCP port and that is not correct, all the protocols should get allowed.