### PR TITLE
Removing the upgrade code from Kuryr-Kubernetes repo

### DIFF
--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy.py
@@ -242,13 +242,6 @@ class TestNetworkPolicyDriver(test_base.TestCase):
         self.assertEqual([], resp)
         self.kubernetes.get.assert_called_once()
 
-    def test_get_from_old_crd(self):
-        knp = self._driver.get_from_old_crd(self.old_crd)
-        self.assertEqual(self.crd['spec'], knp['spec'])
-        self.assertEqual(self.crd['status'], knp['status'])
-        for k in ['name', 'namespace']:
-            self.assertEqual(self.crd['metadata'][k], knp['metadata'][k])
-
     @mock.patch('kuryr_kubernetes.controller.drivers.utils.get_services')
     @mock.patch.object(network_policy.NetworkPolicyDriver,
                        '_get_resource_details')

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrnetworkpolicy.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrnetworkpolicy.py
@@ -95,21 +95,3 @@ class TestPolicyHandler(test_base.TestCase):
         self.assertEqual(self.k8s, self.handler.k8s)
         self.assertEqual(self.os_net, self.handler.os_net)
         self.assertEqual(self.lbaas_driver, self.handler._drv_lbaas)
-
-    def test_convert(self):
-        self_link = ('/apis/openstack.org/v1/namespaces/ns/'
-                     'kuryrnetpolicies/old-knp')
-        self.k8s.get.return_value = {'items': [{
-                'apiVersion': 'openstack.org/v1',
-                'kind': 'KuryrNetPolicy',
-                'metadata': {
-                    'namespace': 'ns',
-                    'name': 'old-knp'
-                }
-            }]}
-        self.np_driver.get_from_old_crd.return_value = mock.sentinel.new_crd
-
-        self.handler._convert_old_crds()
-
-        self.k8s.post.assert_called_once_with(mock.ANY, mock.sentinel.new_crd)
-        self.k8s.delete.assert_called_once_with(self_link)

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_namespace.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_namespace.py
@@ -63,15 +63,13 @@ class TestNamespaceHandler(test_base.TestCase):
         }
         return crd
 
-    @mock.patch.object(namespace.NamespaceHandler, '_upgrade_crds')
     @mock.patch.object(drivers.NamespaceProjectDriver, 'get_instance')
-    def test_init(self, m_get_project_driver, m_upgrade_crds):
+    def test_init(self, m_get_project_driver):
         project_driver = mock.sentinel.project_driver
         m_get_project_driver.return_value = project_driver
 
         handler = namespace.NamespaceHandler()
         self.assertEqual(project_driver, handler._drv_project)
-        m_upgrade_crds.assert_called_once()
 
     def test_on_present(self):
         self._get_kns_crd.return_value = None


### PR DESCRIPTION
When moving from annotation to CRD a compatibility code was added
to allow user to upgrade from ussuri to victoria version. Now we are going
to upgrade to wallaby, so everyone should already use CRD and we
can remove the code.