### PR TITLE
Bug 1927244: OpenShift: Add configured subnets to the detected

### DIFF
--- a/kuryr_kubernetes/controller/drivers/node_subnets.py
+++ b/kuryr_kubernetes/controller/drivers/node_subnets.py
@@ -79,12 +79,17 @@ class OpenShiftNodesSubnets(base.NodesSubnetsDriver):
 
     def get_nodes_subnets(self, raise_on_empty=False):
         with lockutils.lock('kuryr-machine-add'):
-            if not self.subnets and raise_on_empty:
+            # We add any hardcoded ones from config anyway.
+            result = self.subnets
+            if CONF.pod_vif_nested.worker_nodes_subnets:
+                result = result.union(
+                    set(CONF.pod_vif_nested.worker_nodes_subnets))
+            if not result and raise_on_empty:
                 raise exceptions.ResourceNotReady(
                     'OpenShift Machines does not exist or are not yet '
                     'handled. Cannot determine worker nodes subnets.')
 
-            return list(self.subnets)
+            return list(result)
 
     def add_node(self, machine):
         subnet_id = self._get_subnet_from_machine(machine)

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_node_subnets.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_node_subnets.py
@@ -100,6 +100,8 @@ class TestOpenShiftNodesSubnetsDriver(test_base.TestCase):
             },
             "status": {}
         }
+        cfg.CONF.set_override('worker_nodes_subnets', [],
+                              group='pod_vif_nested')
 
     def test_get_nodes_subnets(self):
         subnets = ['subnet1', 'subnet2']
@@ -107,6 +109,16 @@ class TestOpenShiftNodesSubnetsDriver(test_base.TestCase):
         for subnet in subnets:
             driver.subnets.add(subnet)
         self.assertCountEqual(subnets, driver.get_nodes_subnets())
+
+    def test_get_nodes_subnets_with_config(self):
+        subnets = ['subnet1', 'subnet2']
+        cfg.CONF.set_override('worker_nodes_subnets', ['subnet3', 'subnet2'],
+                              group='pod_vif_nested')
+        driver = node_subnets.OpenShiftNodesSubnets()
+        for subnet in subnets:
+            driver.subnets.add(subnet)
+        self.assertCountEqual(['subnet1', 'subnet2', 'subnet3'],
+                              driver.get_nodes_subnets())
 
     def test_get_nodes_subnets_not_raise(self):
         driver = node_subnets.OpenShiftNodesSubnets()


### PR DESCRIPTION
Turns out there's an OpenShift mode where it's required to actually
hardcode a worker_nodes_subnet as some nodes does not have the Machine
objects. This commit solves that by making sure that
[pod_vif_nested]worker_nodes_subnets are also added to whatever the
OpenShiftNodesSubnets driver detects.