### PR TITLE
Bug 1929170: CNI: Protect from '' being passed as CNI_NETNS

### DIFF
--- a/kuryr_kubernetes/cni/binding/nested.py
+++ b/kuryr_kubernetes/cni/binding/nested.py
@@ -53,8 +53,13 @@ class NestedDriver(health.HealthHandler, b_base.BaseBindingDriver):
         # First let's take a peek into the pod namespace and try to remove any
         # leftover interface in case we got restarted before CNI returned to
         # kubelet.
-        with b_base.get_ipdb(netns) as c_ipdb:
-            self._remove_ifaces(c_ipdb, (temp_name, ifname), netns)
+        # NOTE(dulek): CNI spec guarantees getting correct CNI_NETNS in the CNI
+        #              request. Unfortunately some CNI implementations doesn't
+        #              do that so let's protect here from attemtps to remove
+        #              `eth0` on host netns when '' is passed as CNI_NETNS.
+        if netns:
+            with b_base.get_ipdb(netns) as c_ipdb:
+                self._remove_ifaces(c_ipdb, (temp_name, ifname), netns)
 
         # We might also have leftover interface in the host netns, let's try to
         # remove it too. This is outside of the main host's IPDB context
@@ -100,8 +105,13 @@ class NestedDriver(health.HealthHandler, b_base.BaseBindingDriver):
         #              the old netns is deleted. This might result in VLAN ID
         #              conflict. In oder to protect from that let's remove the
         #              netns ifaces here anyway.
-        with b_base.get_ipdb(netns) as c_ipdb:
-            self._remove_ifaces(c_ipdb, (vif.vif_name, ifname), netns)
+        # NOTE(dulek): CNI spec guarantees getting correct CNI_NETNS in the CNI
+        #              request. Unfortunately some CNI implementations doesn't
+        #              do that so let's protect here from attemtps to remove
+        #              `eth0` on host netns when '' is passed as CNI_NETNS.
+        if netns:
+            with b_base.get_ipdb(netns) as c_ipdb:
+                self._remove_ifaces(c_ipdb, (vif.vif_name, ifname), netns)
 
 
 class VlanDriver(NestedDriver):

--- a/openshift-kuryr-tester.Dockerfile
+++ b/openshift-kuryr-tester.Dockerfile
@@ -6,7 +6,7 @@ RUN yum update -y \
  && yum install -y python-devel python-pbr python-pip \
  && yum clean all \
  && rm -rf /var/cache/yum \
- && pip install -U pip \
+ && pip install -U pip==20.3.3 \
  && pip install "more-itertools<6.0.0" tox
  # more-itertools 6.0.0 drops support for Python 2.7, so we need to ensure we have older version.
 


### PR DESCRIPTION
We've hit cases when openshift-node is passing empty string as CNI_NETNS
in CNI requests. This is against the CNI spec and causes us to try to
remove the host eth0 interface which fails hard. This commit makes sure
we don't attempt to remove leftover container interfaces when '' is
passed as CNI_NETNS.