### PR TITLE
Bug 1929216: Handle Endpoints missing `addresses` field

### DIFF
--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -435,7 +435,7 @@ class LoadBalancerHandler(k8s_base.ResourceEventHandler):
             current_targets = {(a['ip'], p['port'],
                                 spec_ports.get(p.get('name')))
                                for s in endpoints['subsets']
-                               for a in s['addresses']
+                               for a in s.get('addresses', [])
                                for p in s['ports']
                                if p.get('name') in spec_ports}
 


### PR DESCRIPTION
If Pods exposed by the Service have readinessProbe it may happen that
the Endpoints object with a slice will get created for them but it will
only have `notReadyAddresses` and will be missing `addresses` field. We
don't handle that well resulting in controller in a crash loop
complaining on KeyError. This commit fixes that by defaulting
`addresses` lookups to empty list [].