### PR TITLE
Bug 1924075: Skip pool pre population if no Status is present on CRD

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrnetwork_population.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetwork_population.py
@@ -41,13 +41,16 @@ class KuryrNetworkPopulationHandler(k8s_base.ResourceEventHandler):
         self._drv_vif_pool.set_vif_driver()
         self._drv_nodes_subnets = drivers.NodesSubnetsDriver.get_instance()
 
-    def on_added(self, kuryrnet_crd):
-        subnet_id = kuryrnet_crd['status'].get('subnetId')
+    def on_present(self, kuryrnet_crd):
+        subnet_id = kuryrnet_crd.get('status', {}).get('subnetId')
         if not subnet_id:
+            LOG.debug("No Subnet present for KuryrNetwork %s",
+                      kuryrnet_crd['metadata']['name'])
             return
 
         if kuryrnet_crd['status'].get('populated'):
-            LOG.debug("Subnet %s already populated", subnet_id)
+            LOG.debug("Subnet %s already populated for Namespace %s",
+                      subnet_id, kuryrnet_crd['metadata']['name'])
             return
 
         namespace = kuryrnet_crd['spec'].get('nsName')

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrnetwork_population.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrnetwork_population.py
@@ -81,12 +81,12 @@ class TestKuryrNetworkPopulationHandler(test_base.TestCase):
     @mock.patch.object(driver_utils, 'get_annotations')
     @mock.patch.object(driver_utils, 'get_namespace')
     @mock.patch.object(utils, 'get_nodes_ips')
-    def test_on_added(self, m_get_nodes_ips, m_get_ns, m_get_ann):
+    def test_on_present(self, m_get_nodes_ips, m_get_ns, m_get_ann):
         m_get_nodes_ips.return_value = ['node-ip']
         m_get_ns.return_value = mock.sentinel.ns
         m_get_ann.return_value = self._kuryrnet_crd['metadata']['name']
 
-        kuryrnetwork_population.KuryrNetworkPopulationHandler.on_added(
+        kuryrnetwork_population.KuryrNetworkPopulationHandler.on_present(
             self._handler, self._kuryrnet_crd)
 
         self._get_namespace_subnet.assert_called_once_with(
@@ -99,7 +99,7 @@ class TestKuryrNetworkPopulationHandler(test_base.TestCase):
 
     def test_on_added_no_subnet(self):
         kns = self._kuryrnet_crd.copy()
-        kns['status'] = {}
+        del kns['status']
         kuryrnetwork_population.KuryrNetworkPopulationHandler.on_added(
             self._handler, kns)
         self._get_namespace_subnet.assert_not_called()


### PR DESCRIPTION
In case the kuryrnetwork_population handler is enabled
and a Namespace creation was triggered, it's possible that
the kuryrnetwork_population handler attempts to do its job
before the KuryrNetwork handles the CR update with status field.
This commit fixes this race by skipping the event for the
kuryrnetwork_population when no 'status' is present and
modifying the event to be handled on a on_present operation
since the on_added would only be triggered once.

Closes-bug: 1916544
Change-Id: I7221c67990a3dd6974ea362d209390c716540ceb