### PR TITLE
Bug 1918568: Raise ResourceNotReady when deleting ERROR LB

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -1026,7 +1026,7 @@ class LBaaSv2Driver(base.LBaaSDriver):
                 LOG.debug("Releasing loadbalancer %s with error status",
                           loadbalancer['id'])
                 self.release_loadbalancer(loadbalancer)
-                break
+                raise k_exc.ResourceNotReady(loadbalancer['id'])
             else:
                 LOG.debug("Provisioning status %(status)s for %(lb)s, "
                           "%(rem).3gs remaining until timeout",


### PR DESCRIPTION
When deleting LB in ERROR status we need to make sure the event is
retried on order for the LB to get recreated. This commit makes sure
that happens by raising ResourceNotReady after deleting the LB.