### PR TITLE
Handle Kubernetes default Service

### DIFF
--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -94,9 +94,6 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
             return ('Skipping annotated service %s, waiting for it to be '
                     'converted to KuryrLoadBalancer object and annotation '
                     'removed.')
-        if utils.is_kubernetes_default_resource(service):
-            # Avoid to handle default Kubernetes service as requires https.
-            return 'Skipping default service %s.'
         return None
 
     def _patch_service_finalizer(self, service):
@@ -266,8 +263,7 @@ class EndpointsHandler(k8s_base.ResourceEventHandler):
         if (not (self._has_pods(endpoints) or (loadbalancer_crd and
                                                loadbalancer_crd.get('status')))
                 or k_const.K8S_ANNOTATION_HEADLESS_SERVICE
-                in endpoints['metadata'].get('labels', []) or
-                utils.is_kubernetes_default_resource(endpoints)):
+                in endpoints['metadata'].get('labels', [])):
             LOG.debug("Ignoring Kubernetes endpoints %s",
                       endpoints['metadata']['name'])
             return

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -551,21 +551,6 @@ def clean_lb_crd_status(loadbalancer_name):
         raise
 
 
-def is_kubernetes_default_resource(obj):
-    """Check if Object is a resource associated to the API
-
-    Verifies if the Object is on the default namespace
-    and has the name kubernetes. Those name and namespace
-    are given to Kubernetes Service and Endpoints for the API.
-
-    :param obj: Kubernetes object dict
-    :returns: True if is default resource for the API, false
-              otherwise.
-    """
-    return (obj['metadata']['name'] == 'kubernetes' and
-            obj['metadata']['namespace'] == 'default')
-
-
 def get_pod_by_ip(pod_ip, namespace=None):
     k8s = clients.get_kubernetes_client()
     pod = {}


### PR DESCRIPTION
This commit allows Kuryr to handle the default Kuberntes Service
and ensure the load balancer is created with the provider that is
configured. To support Kuryr detecting the existent lb upon upgrade,
the CRD needs to be filled with The Load Balancer, Listener and Pool
for Kuryr to properly clean up the resources and recreate them with
the configured provider and protocol.