### PR TITLE
Bug 1940141: Do not default protocol to TCP for allow-all NPs

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -198,8 +198,9 @@ class LBaaSv2Driver(base.LBaaSDriver):
                     # with or without remote_ip_prefix.
                     if rule.remote_group_id:
                         continue
-                    if (rule.protocol == protocol.lower() and
-                            rule.direction == 'ingress'):
+                    if ((not rule.protocol or
+                         rule.protocol == protocol.lower())
+                            and rule.direction == 'ingress'):
                         # If listener port not in allowed range, skip
                         min_port = rule.port_range_min
                         max_port = rule.port_range_max

--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -283,7 +283,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
             for container_port, pods in matched_pods.items():
                 sg_rule = driver_utils.create_security_group_rule_body(
                     direction, container_port,
-                    protocol=port.get('protocol'),
+                    # Pod's spec.containers[].port.protocol defaults to TCP
+                    protocol=port.get('protocol', 'TCP'),
                     cidr=cidr, pods=pods)
                 if sg_rule not in crd_rules:
                     crd_rules.append(sg_rule)
@@ -291,7 +292,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     self._create_svc_egress_sg_rule(
                         policy_namespace, crd_rules,
                         resource=resource, port=container_port,
-                        protocol=port.get('protocol'))
+                        # Pod's spec.containers[].port.protocol defaults to TCP
+                        protocol=port.get('protocol', 'TCP'))
 
     def _create_sg_rule_body_on_text_port(self, direction, port,
                                           resources, crd_rules, pod_selector,
@@ -346,7 +348,7 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 for ethertype in (constants.IPv4, constants.IPv6):
                     sg_rule = driver_utils.create_security_group_rule_body(
                         direction, container_port,
-                        protocol=port.get('protocol'),
+                        protocol=port.get('protocol', 'TCP'),
                         ethertype=ethertype,
                         pods=pods)
                     crd_rules.append(sg_rule)
@@ -368,7 +370,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
             sg_rule = (
                 driver_utils.create_security_group_rule_body(
                     direction, port.get('port'),
-                    protocol=port.get('protocol'),
+                    # NP's ports[].protocol defaults to TCP
+                    protocol=port.get('protocol', 'TCP'),
                     cidr=cidr,
                     namespace=ns))
             sg_rule_body_list.append(sg_rule)
@@ -376,7 +379,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 self._create_svc_egress_sg_rule(
                     policy_namespace, sg_rule_body_list,
                     resource=resource, port=port.get('port'),
-                    protocol=port.get('protocol'))
+                    # NP's ports[].protocol defaults to TCP
+                    protocol=port.get('protocol', 'TCP'))
 
     def _create_all_pods_sg_rules(self, port, direction,
                                   sg_rule_body_list, pod_selector,
@@ -393,7 +397,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     driver_utils.create_security_group_rule_body(
                         direction, port.get('port'),
                         ethertype=ethertype,
-                        protocol=port.get('protocol')))
+                        # NP's ports[].protocol defaults to TCP
+                        protocol=port.get('protocol', 'TCP')))
                 sg_rule_body_list.append(sg_rule)
                 if direction == 'egress':
                     self._create_svc_egress_sg_rule(

--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -585,7 +585,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 if ns_name != resource['metadata']['name']:
                     continue
             cluster_ip = service['spec'].get('clusterIP')
-            if not cluster_ip:
+            if not cluster_ip or cluster_ip == 'None':
+                # Headless services has 'None' as clusterIP.
                 continue
             rule = driver_utils.create_security_group_rule_body(
                 'egress', port, protocol=protocol,

--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -249,13 +249,9 @@ def create_security_group_rule_body(
         ethertype='IPv4', cidr=None,
         description="Kuryr-Kubernetes NetPolicy SG rule", namespace=None,
         pods=None):
-    if not port_range_min:
-        port_range_min = 1
-        port_range_max = 65535
-    elif not port_range_max:
+
+    if port_range_min and not port_range_max:
         port_range_max = port_range_min
-    if not protocol:
-        protocol = 'TCP'
 
     if cidr and netaddr.IPNetwork(cidr).version == 6:
         ethertype = 'IPv6'
@@ -265,11 +261,13 @@ def create_security_group_rule_body(
             'ethertype': ethertype,
             'description': description,
             'direction': direction,
-            'protocol': protocol.lower(),
-            'port_range_min': port_range_min,
-            'port_range_max': port_range_max,
         }
     }
+    if port_range_min and port_range_max:
+        security_group_rule_body['sgRule']['port_range_min'] = port_range_min
+        security_group_rule_body['sgRule']['port_range_max'] = port_range_max
+    if protocol:
+        security_group_rule_body['sgRule']['protocol'] = protocol.lower()
     if cidr:
         security_group_rule_body['sgRule']['remote_ip_prefix'] = cidr
     if namespace:


### PR DESCRIPTION
Seems like we misunderstood the NP API reference and default the
protocol to TCP when creating SGs for NPs that are supposed to open all
traffic. That is incorrect and we should not specify a protocol in such
cases. This commit fixes that.

Change-Id: Ie7936555ac794f10443e48908b7b5b2494525b7c
Closes-Bug: 1914380