### PR TITLE
Bug 1938960: Ignore headless services in NP code

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -595,7 +595,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 if ns_name != resource['metadata']['name']:
                     continue
             cluster_ip = service['spec'].get('clusterIP')
-            if not cluster_ip:
+            if not cluster_ip or cluster_ip == 'None':
+                # Headless services has 'None' as clusterIP.
                 continue
             rule = driver_utils.create_security_group_rule_body(
                 'egress', port, protocol=protocol,


### PR DESCRIPTION
Seems like we need special handling of headless services in NP code that
is to ignore them if they have "None" string as a clusterIP.