### PR TITLE
Handle default Kubernetes Service

### DIFF
--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -94,9 +94,6 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
             return ('Skipping annotated service %s, waiting for it to be '
                     'converted to KuryrLoadBalancer object and annotation '
                     'removed.')
-        if utils.is_kubernetes_default_resource(service):
-            # Avoid to handle default Kubernetes service as requires https.
-            return 'Skipping default service %s.'
         return None
 
     def _patch_service_finalizer(self, service):
@@ -304,8 +301,7 @@ class EndpointsHandler(k8s_base.ResourceEventHandler):
         if (not (self._has_pods(endpoints) or (loadbalancer_crd and
                                                loadbalancer_crd.get('status')))
                 or k_const.K8S_ANNOTATION_HEADLESS_SERVICE
-                in endpoints['metadata'].get('labels', []) or
-                utils.is_kubernetes_default_resource(endpoints)):
+                in endpoints['metadata'].get('labels', [])):
             LOG.debug("Ignoring Kubernetes endpoints %s",
                       endpoints['metadata']['name'])
             return

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
@@ -264,7 +264,6 @@ class TestLBaaSv2Driver(test_base.TestCase):
     def test_ensure_pool(self):
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
-        expected_resp = mock.sentinel.expected_resp
         loadbalancer = {
             'project_id': 'TEST_PROJECT',
             'id': '00EE9E11-91C2-41CF-8FD4-7970579E5C4C',
@@ -274,7 +273,15 @@ class TestLBaaSv2Driver(test_base.TestCase):
             'name': 'TEST_LISTENER_NAME',
             'protocol': 'TCP',
         }
-        m_driver._ensure_provisioned.return_value = expected_resp
+        resp_pool = {
+            'name': 'TEST_NAME',
+            'project_id': 'TEST_PROJECT',
+            'loadbalancer_id': '00EE9E11-91C2-41CF-8FD4-7970579E5C4C',
+            'listener_id': 'A57B7771-6050-4CA8-A63C-443493EC98AB',
+            'protocol': 'TCP',
+            'id': 'D4F35594-27EB-4F4C-930C-31DD40F53B77'
+        }
+        m_driver._ensure_provisioned.return_value = resp_pool
 
         resp = cls.ensure_pool(m_driver, loadbalancer, listener)
 
@@ -286,7 +293,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         self.assertEqual(loadbalancer['project_id'], pool['project_id'])
         self.assertEqual(listener['id'], pool['listener_id'])
         self.assertEqual(listener['protocol'], pool['protocol'])
-        self.assertEqual(expected_resp, resp)
+        self.assertEqual(resp_pool, resp)
 
     def test_release_pool(self):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
@@ -553,6 +560,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
     def test_create_listener(self):
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        m_driver._octavia_timeouts = True
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         listener = {
             'name': 'TEST_NAME',
@@ -580,6 +588,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
     def test_create_listener_with_different_timeouts(self):
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        m_driver._octavia_timeouts = True
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         listener = {
             'name': 'TEST_NAME',

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -551,21 +551,6 @@ def clean_lb_crd_status(loadbalancer_name):
         raise
 
 
-def is_kubernetes_default_resource(obj):
-    """Check if Object is a resource associated to the API
-
-    Verifies if the Object is on the default namespace
-    and has the name kubernetes. Those name and namespace
-    are given to Kubernetes Service and Endpoints for the API.
-
-    :param obj: Kubernetes object dict
-    :returns: True if is default resource for the API, false
-              otherwise.
-    """
-    return (obj['metadata']['name'] == 'kubernetes' and
-            obj['metadata']['namespace'] == 'default')
-
-
 def get_pod_by_ip(pod_ip, namespace=None):
     k8s = clients.get_kubernetes_client()
     pod = {}


### PR DESCRIPTION
This commit allows Kuryr to handle the default Kuberntes Service
and ensure the load balancer is created with the provider that is
configured. Firstly, Kuryr detects the existent lb upon upgrade,
and delete the Load Balancer, the operation is then retried and lb
is created.