### PR TITLE
Bug 1936342: kuryr-controller restarting after 3 days cluster running - pools without members

### DIFF
--- a/kuryr_kubernetes/controller/handlers/loadbalancer.py
+++ b/kuryr_kubernetes/controller/handlers/loadbalancer.py
@@ -536,10 +536,11 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
             removed_ids.add(pool['id'])
         if removed_ids:
             loadbalancer_crd['status']['pools'] = [p for p in loadbalancer_crd[
-                'status']['pools'] if p['id'] not in removed_ids]
+                'status'].get('pools', []) if p['id'] not in removed_ids]
             loadbalancer_crd['status']['members'] = [m for m in
                                                      loadbalancer_crd[
-                                                         'status']['members']
+                                                         'status'].get(
+                                                         'members', [])
                                                      if m['pool_id'] not in
                                                      removed_ids]
 


### PR DESCRIPTION
This patch is fixing the bug in which was problem to
delete pools without members. Instead deleting pools
kuryr-controller was restarting because of this.