### PR TITLE
Bug 1947343: NPs: Do not set ports for protocol-less SG rules

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -520,8 +520,6 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                         continue
                     rule = driver_utils.create_security_group_rule_body(
                         direction,
-                        port_range_min=1,
-                        port_range_max=65535,
                         cidr=cidr,
                         namespace=namespace)
                     sg_rule_body_list.append(rule)
@@ -533,8 +531,6 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     for ethertype in (constants.IPv4, constants.IPv6):
                         rule = driver_utils.create_security_group_rule_body(
                             direction,
-                            port_range_min=1,
-                            port_range_max=65535,
                             ethertype=ethertype)
                         sg_rule_body_list.append(rule)
                         if direction == 'egress':

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy.py
@@ -345,12 +345,8 @@ class TestNetworkPolicyDriver(test_base.TestCase):
         self._driver.parse_network_policy_rules(policy)
         m_get_namespaces.assert_called()
         m_get_resource_details.assert_called()
-        calls = [mock.call('ingress', port_range_min=1,
-                           port_range_max=65535, cidr=subnet_cidr,
-                           namespace=namespace),
-                 mock.call('egress', port_range_min=1,
-                           port_range_max=65535, cidr=subnet_cidr,
-                           namespace=namespace)]
+        calls = [mock.call('ingress', cidr=subnet_cidr, namespace=namespace),
+                 mock.call('egress', cidr=subnet_cidr, namespace=namespace)]
         m_create.assert_has_calls(calls)
 
     @mock.patch.object(network_policy.NetworkPolicyDriver, 'namespaced_pods')


### PR DESCRIPTION
This is a fix for a missing backport.

Change-Id: Ia3af9b99a27663530efa82ca77bdd7bd733c2284