### PR TITLE
Bug 1949480: Fix constant update of Listeners timeout

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -663,6 +663,8 @@ class LBaaSv2Driver(base.LBaaSDriver):
                 LOG.debug("Releasing listener %s", os_listener.id)
                 self.release_listener(loadbalancer, listener)
                 return None
+            if not self._octavia_timeouts:
+                return listener
             if (timeout_cli and (
                     os_listener.timeout_client_data != timeout_cli)) or (
                         timeout_mb and (

--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -606,8 +606,10 @@ class LBaaSv2Driver(base.LBaaSDriver):
         lbaas = clients.get_loadbalancer_client()
         response = lbaas.create_listener(**request)
         listener['id'] = response.id
-        listener['timeout_client_data'] = response.timeout_client_data
-        listener['timeout_member_data'] = response.timeout_member_data
+        if timeout_cli:
+            listener['timeout_client_data'] = response.timeout_client_data
+        if timeout_mem:
+            listener['timeout_member_data'] = response.timeout_member_data
         return listener
 
     def _update_listener_acls(self, loadbalancer, listener_id, allowed_cidrs):

--- a/kuryr_kubernetes/controller/handlers/loadbalancer.py
+++ b/kuryr_kubernetes/controller/handlers/loadbalancer.py
@@ -595,8 +595,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
     def _add_new_listeners(self, loadbalancer_crd):
         changed = False
         lb_crd_spec_ports = loadbalancer_crd['spec'].get('ports')
-        spec_t_cli = loadbalancer_crd['spec'].get('timeout_client_data')
-        spec_t_mb = loadbalancer_crd['spec'].get('timeout_member_data')
+        spec_t_cli = loadbalancer_crd['spec'].get('timeout_client_data', 0)
+        spec_t_mb = loadbalancer_crd['spec'].get('timeout_member_data', 0)
         if not lb_crd_spec_ports:
             return changed
         lbaas_spec_ports = sorted(lb_crd_spec_ports,
@@ -609,8 +609,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
 
             listener = []
             for l in loadbalancer_crd['status'].get('listeners', []):
-                timeout_cli = l.get('timeout_client_data')
-                timeout_mb = l.get('timeout_member_data')
+                timeout_cli = l.get('timeout_client_data', 0)
+                timeout_mb = l.get('timeout_member_data', 0)
                 if l['port'] == port and l['protocol'] == protocol:
                     if timeout_cli == spec_t_cli and timeout_mb == spec_t_mb:
                         listener.append(l)

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
@@ -620,6 +620,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        m_driver._octavia_timeouts = True
         loadbalancer = {
             'id': '00EE9E11-91C2-41CF-8FD4-7970579E5C4C',
         }


### PR DESCRIPTION
The listeners timeout are constantly updated with
Octavia default values, even if no annotation was
updated on the respective Service. The constant
execution of this task makes the Load Balancer
to be stuck with PENDING_UPDATE status. This commit
fixes the issue by ensuring the listener values
are only added to the CR once there was annotation
changes, also it enforces the default values of not
existence of the field to be the same.

This PR also includes a fix to avoid the listener timeout
update when that is not supported in Octavia.