### PR TITLE
Bug 1941941: Include service subnet to be open for namespaceSelector set to all.

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -231,9 +231,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                     # service subnet.
                     allowed_cidrs = utils.get_subnetpool_cidrs(
                         CONF.namespace_subnet.pod_subnet_pool)
-                    if CONF.octavia_defaults.enforce_sg_rules:
-                        allowed_cidrs.append(utils.get_subnet_cidr(
-                            CONF.neutron_defaults.service_subnet))
+                    allowed_cidrs.append(utils.get_subnet_cidr(
+                        CONF.neutron_defaults.service_subnet))
             elif namespace_selector:
                 selectors = True
                 if pod_selector:


### PR DESCRIPTION
For OVN Ocatvia provider we need to include service subnet as well,
otherwise we will end up in no connectivity to services from pods where
network policy which define egress to all namespaces was applied.

Change-Id: Ic1d1803c178a9b8375f2a08e021f0a046fd7ff02
Related-Bug: 1915008
(cherry picked from commit bfe2e259a82dc11056338529c7a01f15a3e002b8)
(cherry picked from commit bb55f676b868232adfb36b06794b79f54e1425e2)