### PR TITLE
Bug 1932114: Allow to config network MTU

### DIFF
--- a/kuryr_kubernetes/cni/binding/bridge.py
+++ b/kuryr_kubernetes/cni/binding/bridge.py
@@ -39,12 +39,9 @@ class BaseBridgeDriver(health.HealthHandler, b_base.BaseBindingDriver):
         with b_base.get_ipdb() as h_ipdb:
             self._remove_ifaces(h_ipdb, (host_ifname,))
 
-        if vif.network.mtu:
-            interface_mtu = vif.network.mtu
-        else:
-            LOG.info("Default mtu %(mtu)s is used for interface, "
-                     "for mtu of network if configured with 0",
-                     {"mtu": CONF.neutron_defaults.network_device_mtu})
+        interface_mtu = vif.network.mtu
+        mtu_cfg = CONF.neutron_defaults.network_device_mtu
+        if mtu_cfg and mtu_cfg < interface_mtu:
             interface_mtu = CONF.neutron_defaults.network_device_mtu
 
         with b_base.get_ipdb(netns) as c_ipdb:

--- a/kuryr_kubernetes/config.py
+++ b/kuryr_kubernetes/config.py
@@ -222,7 +222,7 @@ neutron_defaults = [
                default=None),
     cfg.IntOpt('network_device_mtu',
                help='Default MTU setting for network interface.',
-               default=1500,),
+               default=0,),
     cfg.IntOpt('lbaas_activation_timeout',
                help=_("Time (in seconds) that kuryr controller waits for "
                       "neutron LBaaS to be activated"),

--- a/kuryr_kubernetes/controller/drivers/namespace_subnet.py
+++ b/kuryr_kubernetes/controller/drivers/namespace_subnet.py
@@ -158,10 +158,13 @@ class NamespacePodSubnetDriver(default_subnet.DefaultPodSubnetDriver):
         except StopIteration:
             LOG.debug('Network does not exist. Creating.')
 
+        mtu_cfg = oslo_cfg.CONF.neutron_defaults.network_device_mtu
+        attrs = {'name': net_name, 'project_id': project_id}
+        if mtu_cfg:
+            attrs['mtu'] = mtu_cfg
         # create network with namespace as name
         try:
-            neutron_net = os_net.create_network(name=net_name,
-                                                project_id=project_id)
+            neutron_net = os_net.create_network(**attrs)
             c_utils.tag_neutron_resources([neutron_net])
         except os_exc.SDKException:
             LOG.exception("Error creating neutron resources for the namespace "


### PR DESCRIPTION
We should allow the user to config the mtu
for the namespace networks and for VIFs when
the bridge driver is used.

Change-Id: I1685e31825f15387b6486713ce007b62e915df28