### PR TITLE
Bug 1952429: Narrow connection to the cluster only on namespaceSelector.

### DIFF
--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_network_policy.py
@@ -430,6 +430,7 @@ class TestNetworkPolicyDriver(test_base.TestCase):
         pod_selector = {}
         namespace = mock.sentinel.namespace
         direction = 'ingress'
+        cidrs = ['0.0.0.0/0']
 
         m_get_pods.return_value = {'items': [pod]}
         m_get_ports.return_value = container_ports
@@ -440,7 +441,7 @@ class TestNetworkPolicyDriver(test_base.TestCase):
                                                        crd_rules,
                                                        pod_selector,
                                                        namespace,
-                                                       allow_all=True)
+                                                       allowed_cidrs=cidrs)
 
         m_get_pods.assert_called_with(pod_selector, namespace)
         m_get_ports.assert_called_with(pod, port)
@@ -468,6 +469,7 @@ class TestNetworkPolicyDriver(test_base.TestCase):
         pod_selector = {}
         namespace = mock.sentinel.namespace
         direction = 'ingress'
+        cidrs = ['0.0.0.0/0']
         self._driver._create_sg_rules_with_container_ports = _create_sgr_cont
 
         m_get_pods.return_value = {'items': [pod]}
@@ -479,17 +481,15 @@ class TestNetworkPolicyDriver(test_base.TestCase):
                                                        crd_rules,
                                                        pod_selector,
                                                        namespace,
-                                                       allow_all=True)
+                                                       allowed_cidrs=cidrs)
 
         m_get_pods.assert_called_with(pod_selector, namespace)
         m_get_ports.assert_called_with(pod, port)
 
-        calls = [mock.call(direction, container_ports[0][1],
-                           protocol=port['protocol'], ethertype=e,
-                           pods='foo') for e in ('IPv4', 'IPv6')]
-
-        m_create_sgr.assert_has_calls(calls)
-        self.assertEqual(len(crd_rules), 2)
+        m_create_sgr.assert_called_once_with(direction, container_ports[0][1],
+                                             protocol=port['protocol'],
+                                             cidr=cidrs[0],
+                                             pods='foo')
 
     @mock.patch.object(network_policy.NetworkPolicyDriver,
                        '_create_sg_rules_with_container_ports')
@@ -536,6 +536,7 @@ class TestNetworkPolicyDriver(test_base.TestCase):
         pod_selector = {}
         namespace = mock.sentinel.namespace
         direction = 'egress'
+        cidrs = ['0.0.0.0/0']
 
         m_get_ports.return_value = container_ports
 
@@ -545,7 +546,7 @@ class TestNetworkPolicyDriver(test_base.TestCase):
                                                        crd_rules,
                                                        pod_selector,
                                                        namespace,
-                                                       allow_all=True)
+                                                       allowed_cidrs=cidrs)
 
         m_get_ports.assert_called_with(resources[0], port)
         m_create_sgr.assert_called_once_with('egress', None, cidr=mock.ANY,
@@ -576,6 +577,7 @@ class TestNetworkPolicyDriver(test_base.TestCase):
         pod_selector = {}
         namespace = mock.sentinel.namespace
         direction = 'egress'
+        cidrs = ['0.0.0.0/0']
         self._driver._create_sg_rules_with_container_ports = _create_sgr_cont
         m_get_subnet_cidr.return_value = '10.0.0.128/26'
         m_create_sgr.side_effect = [mock.sentinel.sgr1, mock.sentinel.sgr2,
@@ -590,20 +592,16 @@ class TestNetworkPolicyDriver(test_base.TestCase):
                                                        crd_rules,
                                                        pod_selector,
                                                        namespace,
-                                                       allow_all=True)
+                                                       allowed_cidrs=cidrs)
 
         m_get_ports.assert_called_with(resources[0], port)
-        calls = [mock.call(direction, container_ports[0][1],
-                           protocol=port['protocol'], ethertype=e,
-                           pods='foo') for e in ('IPv4', 'IPv6')]
-        calls.append(mock.call(direction, container_ports[0][1],
-                               protocol=port['protocol'],
-                               cidr='10.0.0.128/26'))
-        m_create_sgr.assert_has_calls(calls)
+        calls = [mock.call('egress', container_ports[0][1], cidr=cidrs[0],
+                           pods='foo', protocol='TCP'),
+                 mock.call('egress', container_ports[0][1],
+                           cidr='10.0.0.128/26', protocol='TCP')]
 
-        # NOTE(gryf): there are 3 rules created in case of egress direction,
-        # since additional one is created for specific cidr in service subnet.
-        self.assertEqual(len(crd_rules), 3)
+        m_create_sgr.assert_has_calls(calls)
+        self.assertEqual(len(crd_rules), 2)
 
     def test__create_all_pods_sg_rules(self):
         port = {'protocol': 'TCP', 'port': 22}

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -232,14 +232,24 @@ def get_subnet_cidr(subnet_id):
 
 
 @MEMOIZE
-def get_subnetpool_version(subnetpool_id):
+def _get_subnetpool(subnetpool_id):
     os_net = clients.get_network_client()
     try:
         subnetpool_obj = os_net.get_subnet_pool(subnetpool_id)
     except os_exc.ResourceNotFound:
         LOG.exception("Subnetpool %s not found!", subnetpool_id)
         raise
+    return subnetpool_obj
+
+
+def get_subnetpool_version(subnetpool_id):
+    subnetpool_obj = _get_subnetpool(subnetpool_id)
     return subnetpool_obj.ip_version
+
+
+def get_subnetpool_cidrs(subnetpool_id):
+    subnetpool_obj = _get_subnetpool(subnetpool_id)
+    return subnetpool_obj.prefixes
 
 
 def extract_pod_annotation(annotation):


### PR DESCRIPTION
For simple case, when operator wants to open connection to all the
namespaces in the cluster, i.e.:

kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: networkpolicy-example
spec:
  podSelector: {}
  policyTypes:
  - Egress
  - Ingress
  egress:
  - to:
    - namespaceSelector: {}

there was false assumption, that we need to open it without any
restriction, while the truth is, that all we need to do is to open
egress network to all the namespaces within cluster.

Change-Id: Ibea039fa9c3b46b83e99237ce2ceb03f02d50727
Closes-Bug: 1915008
(cherry picked from commit 304bc1bc2a8724fc07660c6f7e163618dc2c2e27)