### PR TITLE
Bug 1955024: CNI: Use golang 1.15 for building

### DIFF
--- a/openshift-kuryr-cni-ci.Dockerfile
+++ b/openshift-kuryr-cni-ci.Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.11 AS builder
+FROM openshift/origin-release:golang-1.15 AS builder
 
 WORKDIR /go/src/github.com/openshift/kuryr-kubernetes
 COPY . .

--- a/openshift-kuryr-cni.Dockerfile
+++ b/openshift-kuryr-cni.Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.11 AS builder
+FROM openshift/origin-release:golang-1.15 AS builder
 
 WORKDIR /go/src/github.com/openshift/kuryr-kubernetes
 COPY . .


### PR DESCRIPTION
golang 1.11 is unsupported, let's upgrade it.