### PR TITLE
Bug 1957315: Fix readiness quota check

### DIFF
--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -370,13 +370,13 @@ def has_limit(quota):
 
 def is_available(resource, resource_quota):
     availability = resource_quota['limit'] - resource_quota['used']
-    if availability <= 3:
-        LOG.warning("Neutron quota low for %s. Used %d out of %d limit.",
-                    resource, resource_quota['limit'], resource_quota['used'])
-    elif availability <= 0:
+    if availability <= 0:
         LOG.error("Neutron quota exceeded for %s. Used %d out of %d limit.",
-                  resource, resource_quota['limit'], resource_quota['used'])
+                  resource, resource_quota['used'], resource_quota['limit'])
         return False
+    elif availability <= 3:
+        LOG.warning("Neutron quota low for %s. Used %d out of %d limit.",
+                    resource, resource_quota['used'], resource_quota['limit'])
     return True
 
 


### PR DESCRIPTION
Due to coding error I not only switched "used" with "limit" in our
quota check messages but also made it impossible for the check to fail.
This commit fixes it.