### PR TITLE
Bug 1954353: Ensure LB resources with ERROR status are deleted

### DIFF
--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_lbaasv2.py
@@ -528,13 +528,15 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer(
+            id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         listener = obj_lbaas.LBaaSListener(
             name='TEST_NAME', project_id='TEST_PROJECT', protocol='TCP',
             port=1234, loadbalancer_id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         listener_id = 'A57B7771-6050-4CA8-A63C-443493EC98AB'
         lbaas.listeners.return_value = iter([o_lis.Listener(id=listener_id)])
 
-        ret = cls._find_listener(m_driver, listener)
+        ret = cls._find_listener(m_driver, listener, loadbalancer)
         lbaas.listeners.assert_called_once_with(
             name=listener.name,
             project_id=listener.project_id,
@@ -550,13 +552,15 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer(
+            id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         listener = obj_lbaas.LBaaSListener(
             name='TEST_NAME', project_id='TEST_PROJECT', protocol='TCP',
             port=1234, loadbalancer_id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         resp = iter([])
         lbaas.listeners.return_value = resp
 
-        ret = cls._find_listener(m_driver, listener)
+        ret = cls._find_listener(m_driver, listener, loadbalancer)
         lbaas.listeners.assert_called_once_with(
             name=listener.name,
             project_id=listener.project_id,
@@ -616,6 +620,8 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer(
+            id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         pool = obj_lbaas.LBaaSPool(
             name='TEST_NAME', project_id='TEST_PROJECT', protocol='TCP',
             listener_id='A57B7771-6050-4CA8-A63C-443493EC98AB',
@@ -625,7 +631,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
                             listeners=[{"id": pool.listener_id}])]
         lbaas.pools.return_value = resp
 
-        ret = cls._find_pool(m_driver, pool)
+        ret = cls._find_pool(m_driver, pool, loadbalancer)
         lbaas.pools.assert_called_once_with(
             name=pool.name,
             project_id=pool.project_id,
@@ -640,6 +646,8 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer(
+            id='00EE9E11-91C2-41CF-8FD4-7970579E5C4C')
         pool = obj_lbaas.LBaaSPool(
             name='TEST_NAME', project_id='TEST_PROJECT', protocol='TCP',
             listener_id='A57B7771-6050-4CA8-A63C-443493EC98AB',
@@ -647,7 +655,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         resp = []
         lbaas.pools.return_value = resp
 
-        ret = cls._find_pool(m_driver, pool)
+        ret = cls._find_pool(m_driver, pool, loadbalancer)
         lbaas.pools.assert_called_once_with(
             name=pool.name,
             project_id=pool.project_id,
@@ -684,6 +692,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer()
         member = obj_lbaas.LBaaSMember(
             name='TEST_NAME', project_id='TEST_PROJECT', ip='1.2.3.4',
             port=1234, subnet_id='D3FA400A-F543-4B91-9CD3-047AF0CE42D1',
@@ -692,7 +701,8 @@ class TestLBaaSv2Driver(test_base.TestCase):
         member_id = '3A70CEC0-392D-4BC1-A27C-06E63A0FD54F'
         resp = iter([o_mem.Member(id=member_id, name='TEST_NAME')])
         lbaas.members.return_value = resp
-        ret = cls._find_member(m_driver, member)
+
+        ret = cls._find_member(m_driver, member, loadbalancer)
         lbaas.members.assert_called_once_with(
             member.pool_id,
             project_id=member.project_id,
@@ -710,6 +720,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         lbaas = self.useFixture(k_fix.MockLBaaSClient()).client
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
+        loadbalancer = obj_lbaas.LBaaSLoadBalancer()
         member = obj_lbaas.LBaaSMember(
             name='TEST_NAME', project_id='TEST_PROJECT', ip='1.2.3.4',
             port=1234, subnet_id='D3FA400A-F543-4B91-9CD3-047AF0CE42D1',
@@ -717,7 +728,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
         resp = iter([])
         lbaas.members.return_value = resp
 
-        ret = cls._find_member(m_driver, member)
+        ret = cls._find_member(m_driver, member, loadbalancer)
         lbaas.members.assert_called_once_with(
             member.pool_id,
             project_id=member.project_id,
@@ -730,12 +741,14 @@ class TestLBaaSv2Driver(test_base.TestCase):
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
         obj = mock.Mock()
+        lb = mock.Mock()
         m_create = mock.Mock()
         m_find = mock.Mock()
         expected_result = mock.sentinel.expected_result
         m_create.return_value = expected_result
 
-        ret = cls._ensure(m_driver, obj, m_create, m_find)
+        ret = cls._ensure(m_driver, m_create, m_find,
+                          obj, lb)
         m_create.assert_called_once_with(obj)
         self.assertEqual(expected_result, ret)
 
@@ -743,15 +756,17 @@ class TestLBaaSv2Driver(test_base.TestCase):
         cls = d_lbaasv2.LBaaSv2Driver
         m_driver = mock.Mock(spec=d_lbaasv2.LBaaSv2Driver)
         obj = mock.Mock()
+        lb = mock.Mock()
         m_create = mock.Mock()
         m_find = mock.Mock()
         expected_result = None
         m_create.side_effect = exception_value
         m_find.return_value = expected_result
 
-        ret = cls._ensure(m_driver, obj, m_create, m_find)
+        ret = cls._ensure(m_driver, m_create, m_find,
+                          obj, lb)
         m_create.assert_called_once_with(obj)
-        m_find.assert_called_once_with(obj)
+        m_find.assert_called_once_with(obj, lb)
         self.assertEqual(expected_result, ret)
 
     def test_ensure_with_conflict(self):
@@ -793,7 +808,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
             [mock.call(loadbalancer, t, d_lbaasv2._LB_STS_POLL_FAST_INTERVAL)
              for t in timer])
         m_driver._ensure.assert_has_calls(
-            [mock.call(obj, create, find) for _ in timer])
+            [mock.call(create, find, obj, loadbalancer) for _ in timer])
 
     def test_ensure_not_ready(self):
         cls = d_lbaasv2.LBaaSv2Driver
@@ -814,7 +829,7 @@ class TestLBaaSv2Driver(test_base.TestCase):
             [mock.call(loadbalancer, t, d_lbaasv2._LB_STS_POLL_FAST_INTERVAL)
              for t in timer])
         m_driver._ensure.assert_has_calls(
-            [mock.call(obj, create, find) for _ in timer])
+            [mock.call(create, find, obj, loadbalancer) for _ in timer])
 
     def test_release(self):
         cls = d_lbaasv2.LBaaSv2Driver


### PR DESCRIPTION
In case a LB resource ends up with ERROR in the provisioning status
we must ensure the deletion and recreation of the resource.

Closes-bug: 1879371
Change-Id: I2531948ab6181cfa5049b54c78935c23f60173d2