### PR TITLE
Bug 1933880: Ignore 422 Unprocessable Entity on KLB patching

### DIFF
--- a/kuryr_kubernetes/controller/handlers/loadbalancer.py
+++ b/kuryr_kubernetes/controller/handlers/loadbalancer.py
@@ -111,17 +111,7 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                     loadbalancer_crd['status'][
                         'service_pub_ip_info'] = service_pub_ip_info
                     self._update_lb_status(loadbalancer_crd)
-                    kubernetes = clients.get_kubernetes_client()
-                    try:
-                        kubernetes.patch_crd('status', utils.get_res_link(
-                            loadbalancer_crd), loadbalancer_crd['status'])
-                    except k_exc.K8sResourceNotFound:
-                        LOG.debug('KuryrLoadbalancer CRD not found %s',
-                                  loadbalancer_crd)
-                    except k_exc.K8sClientException:
-                        LOG.exception('Error updating KuryLoadbalancer CRD %s',
-                                      loadbalancer_crd)
-                        raise
+                    self._patch_status(loadbalancer_crd)
 
     def _should_ignore(self, loadbalancer_crd):
         return (not(self._has_endpoints(loadbalancer_crd) or
@@ -180,6 +170,24 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                           'for %s', service["metadata"]["name"])
             raise
 
+    def _patch_status(self, loadbalancer_crd):
+        kubernetes = clients.get_kubernetes_client()
+        try:
+            kubernetes.patch_crd('status', utils.get_res_link(
+                loadbalancer_crd), loadbalancer_crd['status'])
+        except k_exc.K8sResourceNotFound:
+            LOG.debug('KuryrLoadBalancer CRD not found %s', loadbalancer_crd)
+            return False
+        except k_exc.K8sUnprocessableEntity:
+            LOG.warning('KuryrLoadBalancer %s modified, retrying later.',
+                        utils.get_res_unique_name(loadbalancer_crd))
+            return False
+        except k_exc.K8sClientException:
+            LOG.exception('Error updating KuryLoadbalancer CRD %s',
+                          loadbalancer_crd)
+            raise
+        return True
+
     def _sync_lbaas_members(self, loadbalancer_crd):
         changed = False
 
@@ -226,8 +234,7 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                       'due to missing loadbalancer field.')
             return None
         except k_exc.K8sClientException:
-            LOG.exception('Error syncing KuryrLoadBalancer'
-                          ' %s', svc_name)
+            LOG.exception('Error syncing KuryrLoadBalancer %s', svc_name)
             raise
         return klb_crd
 
@@ -339,17 +346,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                         loadbalancer_crd['status']['members'] = []
                         loadbalancer_crd['status'].get('members', []).append(
                             member)
-                    kubernetes = clients.get_kubernetes_client()
-                    try:
-                        kubernetes.patch_crd('status', utils.get_res_link(
-                            loadbalancer_crd), loadbalancer_crd['status'])
-                    except k_exc.K8sResourceNotFound:
-                        LOG.debug('KuryrLoadbalancer CRD not found %s',
-                                  loadbalancer_crd)
-                    except k_exc.K8sClientException:
-                        LOG.exception('Error updating KuryLoadbalancer CRD %s',
-                                      loadbalancer_crd)
-                        raise
+                    if not self._patch_status(loadbalancer_crd):
+                        return False
                     changed = True
         return changed
 
@@ -467,18 +465,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                        if m['id'] not in removed_ids]
             loadbalancer_crd['status']['members'] = members
 
-            kubernetes = clients.get_kubernetes_client()
-            try:
-                kubernetes.patch_crd('status',
-                                     utils.get_res_link(loadbalancer_crd),
-                                     loadbalancer_crd['status'])
-            except k_exc.K8sResourceNotFound:
-                LOG.debug('KuryrLoadbalancer CRD not found %s',
-                          loadbalancer_crd)
-            except k_exc.K8sClientException:
-                LOG.exception('Error updating KuryLoadbalancer CRD %s',
-                              loadbalancer_crd)
-                raise
+            if not self._patch_status(loadbalancer_crd):
+                return False
         return bool(removed_ids)
 
     def _sync_lbaas_pools(self, loadbalancer_crd):
@@ -516,18 +504,9 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                 loadbalancer_crd['status']['pools'] = []
                 loadbalancer_crd['status'].get('pools', []).append(
                     pool)
-            kubernetes = clients.get_kubernetes_client()
-            try:
-                kubernetes.patch_crd('status',
-                                     utils.get_res_link(loadbalancer_crd),
-                                     loadbalancer_crd['status'])
-            except k_exc.K8sResourceNotFound:
-                LOG.debug('KuryrLoadbalancer CRD not found %s',
-                          loadbalancer_crd)
-            except k_exc.K8sClientException:
-                LOG.exception('Error updating KuryrLoadbalancer CRD %s',
-                              loadbalancer_crd)
-                raise
+
+            if not self._patch_status(loadbalancer_crd):
+                return False
             changed = True
         return changed
 
@@ -564,18 +543,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                                                      if m['pool_id'] not in
                                                      removed_ids]
 
-            kubernetes = clients.get_kubernetes_client()
-            try:
-                kubernetes.patch_crd('status',
-                                     utils.get_res_link(loadbalancer_crd),
-                                     loadbalancer_crd['status'])
-            except k_exc.K8sResourceNotFound:
-                LOG.debug('KuryrLoadbalancer CRD not found %s',
-                          loadbalancer_crd)
-            except k_exc.K8sClientException:
-                LOG.exception('Error updating KuryLoadbalancer CRD %s',
-                              loadbalancer_crd)
-                raise
+            if not self._patch_status(loadbalancer_crd):
+                return False
         return bool(removed_ids)
 
     def _sync_lbaas_listeners(self, loadbalancer_crd):
@@ -652,18 +621,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                     loadbalancer_crd['status'].get('listeners', []).append(
                         listener)
 
-                kubernetes = clients.get_kubernetes_client()
-                try:
-                    kubernetes.patch_crd('status',
-                                         utils.get_res_link(loadbalancer_crd),
-                                         loadbalancer_crd['status'])
-                except k_exc.K8sResourceNotFound:
-                    LOG.debug('KuryrLoadbalancer CRD not found %s',
-                              loadbalancer_crd)
-                except k_exc.K8sClientException:
-                    LOG.exception('Error updating KuryrLoadbalancer CRD %s',
-                                  loadbalancer_crd)
-                    raise
+                if not self._patch_status(loadbalancer_crd):
+                    return False
                 changed = True
         return changed
 
@@ -683,18 +642,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                                                           []) if l['id']
                 not in removed_ids]
 
-            kubernetes = clients.get_kubernetes_client()
-            try:
-                kubernetes.patch_crd('status',
-                                     utils.get_res_link(loadbalancer_crd),
-                                     loadbalancer_crd['status'])
-            except k_exc.K8sResourceNotFound:
-                LOG.debug('KuryrLoadbalancer CRD not found %s',
-                          loadbalancer_crd)
-            except k_exc.K8sClientException:
-                LOG.exception('Error updating KuryLoadbalancer CRD %s',
-                              loadbalancer_crd)
-                raise
+            if not self._patch_status(loadbalancer_crd):
+                return False
         return bool(removed_ids)
 
     def _update_lb_status(self, lb_crd):
@@ -718,7 +667,6 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
             raise
 
     def _sync_lbaas_loadbalancer(self, loadbalancer_crd):
-        changed = False
         lb = loadbalancer_crd['status'].get('loadbalancer')
 
         if lb and lb['ip'] != loadbalancer_crd['spec'].get('ip'):
@@ -757,21 +705,8 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                     provider=loadbalancer_crd['spec'].get('provider'))
                 loadbalancer_crd['status']['loadbalancer'] = lb
 
-            kubernetes = clients.get_kubernetes_client()
-            try:
-                kubernetes.patch_crd('status',
-                                     utils.get_res_link(loadbalancer_crd),
-                                     loadbalancer_crd['status'])
-            except k_exc.K8sResourceNotFound:
-                LOG.debug('KuryrLoadbalancer CRD not found %s',
-                          loadbalancer_crd)
-            except k_exc.K8sClientException:
-                LOG.exception('Error updating KuryrLoadbalancer CRD %s',
-                              loadbalancer_crd)
-                raise
-            changed = True
-
-        return changed
+            return self._patch_status(loadbalancer_crd)
+        return False
 
     def _ensure_release_lbaas(self, loadbalancer_crd):
         attempts = 0
@@ -800,17 +735,7 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                 retry = True
 
             loadbalancer_crd['status'] = {}
-            k8s = clients.get_kubernetes_client()
-            try:
-                k8s.patch_crd('status', utils.get_res_link(loadbalancer_crd),
-                              loadbalancer_crd['status'])
-            except k_exc.K8sResourceNotFound:
-                LOG.debug('KuryrLoadbalancer CRD not found %s',
-                          loadbalancer_crd)
-            except k_exc.K8sClientException:
-                LOG.exception('Error updating KuryrLoadbalancer CRD %s',
-                              loadbalancer_crd)
-                raise
+            self._patch_status(loadbalancer_crd)
             # NOTE(ltomasbo): give some extra time to ensure the Load
             # Balancer VIP is also released
             time.sleep(1)


### PR DESCRIPTION
If we're in the process of handling a KuryrLoadBalancer event and
somebody's tries to delete the `.status` field there, any update we do
on `.status` will result in 422 Unprocessable Entity returned from K8s
API. There's no sense in failing kuryr-controller in that case as the
update should trigger another event and Kuryr should be able to recover
by discovering all the resources and filling the status again.

This commit fixes that by making sure in such situation we stop
processing the event and make the handler wait for the next one.

As a consuequence KLB's 404 returned from patch operations is also
handled as hard stop for further processing of the KuryrLoadBalancer as
there's no point in creating or deleting Octavia resources if the LB is
destined to be cascade deleted.

Change-Id: I5dabded04302268e2c5c25f6c31a5619cd0c28e1
Closes-Bug: 1921109