### PR TITLE
Bug 1968436: Fix Listener timeouts update

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -658,7 +658,6 @@ class LBaaSv2Driver(base.LBaaSDriver):
         try:
             os_listener = next(response)
             listener['id'] = os_listener.id
-            n_listen = None
             if os_listener.provisioning_status == 'ERROR':
                 LOG.debug("Releasing listener %s", os_listener.id)
                 self.release_listener(loadbalancer, listener)
@@ -669,12 +668,13 @@ class LBaaSv2Driver(base.LBaaSDriver):
                     os_listener.timeout_client_data != timeout_cli)) or (
                         timeout_mb and (
                             os_listener.timeout_member_data != timeout_mb)):
+                LOG.debug("Updating listener %s", os_listener.id)
                 n_listen = lbaas.update_listener(os_listener.id, **request)
-            elif not timeout_cli or not timeout_mb:
-                n_listen = lbaas.update_listener(os_listener.id, **request)
-            if n_listen:
                 listener['timeout_client_data'] = n_listen.timeout_client_data
                 listener['timeout_member_data'] = n_listen.timeout_member_data
+            elif not timeout_cli or not timeout_mb:
+                LOG.debug("Updating listener %s", os_listener.id)
+                lbaas.update_listener(os_listener.id, **request)
 
         except (KeyError, StopIteration):
             return None


### PR DESCRIPTION
It's possible that the Listener timeouts data was
included in the CRD status, even though there is
no annotation on the Service, probably the Listener
was not present on the CRD, but created and the
controller attempts to find it and includes the timeouts
value. The timeouts included on the CRD then differs
from the spec values causing the constant update
of the Listener. This commit fixes the issue by ensuring
the timeouts information is only included on the CRD
when there was annoation(s) on the Service.

Closes-bug: 1930220
Change-Id: Iaaa6805287c175de618e0ec20099887f129e7536