### PR TITLE
Bug 1972631: Workaround OVN bug causing subports to be DOWN

### DIFF
--- a/kuryr_kubernetes/cni/handlers.py
+++ b/kuryr_kubernetes/cni/handlers.py
@@ -36,7 +36,7 @@ class CNIHandlerBase(k8s_base.ResourceEventHandler, metaclass=abc.ABCMeta):
         self._callback = on_done
         self._vifs = {}
 
-    def on_present(self, pod):
+    def on_present(self, pod, *args, **kwargs):
         vifs = self._get_vifs(pod)
 
         if self.should_callback(pod, vifs):
@@ -107,7 +107,7 @@ class CallbackHandler(CNIHandlerBase):
     def callback(self):
         self._callback(self._kuryrport, self._callback_vifs)
 
-    def on_deleted(self, kuryrport):
+    def on_deleted(self, kuryrport, *args, **kwargs):
         LOG.debug("Got kuryrport %s deletion event.",
                   kuryrport['metadata']['name'])
         if self._del_callback:

--- a/kuryr_kubernetes/controller/drivers/base.py
+++ b/kuryr_kubernetes/controller/drivers/base.py
@@ -388,7 +388,7 @@ class PodVIFDriver(DriverBase, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def activate_vif(self, vif):
+    def activate_vif(self, vif, **kwargs):
         """Updates VIF to become active.
 
         Implementing drivers should update the specified `vif` object's

--- a/kuryr_kubernetes/controller/drivers/nested_dpdk_vif.py
+++ b/kuryr_kubernetes/controller/drivers/nested_dpdk_vif.py
@@ -64,7 +64,7 @@ class NestedDpdkPodVIFDriver(nested_vif.NestedPodVIFDriver):
                         vif.id, vm_id)
             raise
 
-    def activate_vif(self, vif):
+    def activate_vif(self, vif, **kwargs):
         # NOTE(danil): new virtual interface was created in nova instance
         # during request_vif call, thus if it was not created successfully
         # an exception o_exc.SDKException would be throwed. During binding

--- a/kuryr_kubernetes/controller/drivers/nested_macvlan_vif.py
+++ b/kuryr_kubernetes/controller/drivers/nested_macvlan_vif.py
@@ -86,7 +86,7 @@ class NestedMacvlanPodVIFDriver(nested_vif.NestedPodVIFDriver):
             LOG.warning("Unable to release port %s as it no longer exists.",
                         vif.id)
 
-    def activate_vif(self, vif):
+    def activate_vif(self, vif, **kwargs):
         # NOTE(mchiappe): there is no way to get feedback on the actual
         # interface creation or activation as no plugging can happen for this
         # interface type. However the status of the port is not relevant as

--- a/kuryr_kubernetes/controller/drivers/neutron_vif.py
+++ b/kuryr_kubernetes/controller/drivers/neutron_vif.py
@@ -93,7 +93,7 @@ class NeutronPodVIFDriver(base.PodVIFDriver):
     def release_vif(self, pod, vif, project_id=None, security_groups=None):
         clients.get_network_client().delete_port(vif.id)
 
-    def activate_vif(self, vif):
+    def activate_vif(self, vif, **kwargs):
         if vif.active:
             return
 

--- a/kuryr_kubernetes/controller/drivers/sriov.py
+++ b/kuryr_kubernetes/controller/drivers/sriov.py
@@ -73,7 +73,7 @@ class SriovVIFDriver(neutron_vif.NeutronPodVIFDriver):
         self._reduce_remaining_sriov_vfs(pod, physnet)
         return vif
 
-    def activate_vif(self, vif):
+    def activate_vif(self, vif, **kwargs):
         vif.active = True
 
     def _get_physnet_subnet_mapping(self):

--- a/kuryr_kubernetes/controller/drivers/vif_pool.py
+++ b/kuryr_kubernetes/controller/drivers/vif_pool.py
@@ -118,8 +118,8 @@ class NoopVIFPool(base.VIFPoolDriver):
     def release_vif(self, pod, vif, *argv):
         self._drv_vif.release_vif(pod, vif, *argv)
 
-    def activate_vif(self, vif):
-        self._drv_vif.activate_vif(vif)
+    def activate_vif(self, vif, **kwargs):
+        self._drv_vif.activate_vif(vif, **kwargs)
 
     def update_vif_sgs(self, pod, sgs):
         self._drv_vif.update_vif_sgs(pod, sgs)
@@ -168,8 +168,8 @@ class BaseVIFPool(base.VIFPoolDriver, metaclass=abc.ABCMeta):
     def set_vif_driver(self, driver):
         self._drv_vif = driver
 
-    def activate_vif(self, vif):
-        self._drv_vif.activate_vif(vif)
+    def activate_vif(self, vif, **kwargs):
+        self._drv_vif.activate_vif(vif, **kwargs)
 
     def update_vif_sgs(self, pod, sgs):
         self._drv_vif.update_vif_sgs(pod, sgs)
@@ -1230,9 +1230,9 @@ class MultiVIFPool(base.VIFPoolDriver):
         vif_drv_alias = self._get_vif_drv_alias(vif)
         self._vif_drvs[vif_drv_alias].release_vif(pod, vif, *argv)
 
-    def activate_vif(self, vif):
+    def activate_vif(self, vif, **kwargs):
         vif_drv_alias = self._get_vif_drv_alias(vif)
-        self._vif_drvs[vif_drv_alias].activate_vif(vif)
+        self._vif_drvs[vif_drv_alias].activate_vif(vif, **kwargs)
 
     def update_vif_sgs(self, pod, sgs):
         pod_vif_type = self._get_pod_vif_type(pod)

--- a/kuryr_kubernetes/controller/handlers/kuryrnetwork.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetwork.py
@@ -50,7 +50,7 @@ class KuryrNetworkHandler(k8s_base.ResourceEventHandler):
             self._drv_svc_sg = (
                 drivers.ServiceSecurityGroupsDriver.get_instance())
 
-    def on_present(self, kuryrnet_crd):
+    def on_present(self, kuryrnet_crd, *args, **kwargs):
         ns_name = kuryrnet_crd['spec']['nsName']
         project_id = kuryrnet_crd['spec']['projectId']
         kns_status = kuryrnet_crd.get('status', {})
@@ -90,7 +90,7 @@ class KuryrNetworkHandler(k8s_base.ResourceEventHandler):
             status = {'nsLabels': kuryrnet_crd['spec']['nsLabels']}
             self._patch_kuryrnetwork_crd(kuryrnet_crd, status, labels=True)
 
-    def on_finalize(self, kuryrnet_crd):
+    def on_finalize(self, kuryrnet_crd, *args, **kwargs):
         LOG.debug("Deleting kuryrnetwork CRD resources: %s", kuryrnet_crd)
 
         net_id = kuryrnet_crd.get('status', {}).get('netId')

--- a/kuryr_kubernetes/controller/handlers/kuryrnetwork_population.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetwork_population.py
@@ -41,7 +41,7 @@ class KuryrNetworkPopulationHandler(k8s_base.ResourceEventHandler):
         self._drv_vif_pool.set_vif_driver()
         self._drv_nodes_subnets = drivers.NodesSubnetsDriver.get_instance()
 
-    def on_present(self, kuryrnet_crd):
+    def on_present(self, kuryrnet_crd, *args, **kwargs):
         subnet_id = kuryrnet_crd.get('status', {}).get('subnetId')
         if not subnet_id:
             LOG.debug("No Subnet present for KuryrNetwork %s",

--- a/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetworkpolicy.py
@@ -115,7 +115,7 @@ class KuryrNetworkPolicyHandler(k8s_base.ResourceEventHandler):
 
         return False
 
-    def on_present(self, knp):
+    def on_present(self, knp, *args, **kwargs):
         uniq_name = utils.get_res_unique_name(knp)
         LOG.debug('on_present() for NP %s', uniq_name)
         project_id = self._drv_project.get_project(knp)
@@ -262,7 +262,7 @@ class KuryrNetworkPolicyHandler(k8s_base.ResourceEventHandler):
             raise
         return net_crd['status']['netId']
 
-    def on_finalize(self, knp):
+    def on_finalize(self, knp, *args, **kwargs):
         LOG.debug("Finalizing KuryrNetworkPolicy %s", knp)
         project_id = self._drv_project.get_project(knp)
         pods_to_update = self._drv_policy.affected_pods(knp)

--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -52,7 +52,7 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
         if driver_utils.is_network_policy_enabled():
             driver_utils.bump_networkpolicies(svc['metadata']['namespace'])
 
-    def on_present(self, service):
+    def on_present(self, service, *args, **kwargs):
         reason = self._should_ignore(service)
         if reason:
             LOG.debug(reason, service['metadata']['name'])
@@ -113,7 +113,7 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
         k8s = clients.get_kubernetes_client()
         return k8s.add_finalizer(service, k_const.SERVICE_FINALIZER)
 
-    def on_finalize(self, service):
+    def on_finalize(self, service, *args, **kwargs):
         k8s = clients.get_kubernetes_client()
 
         svc_name = service['metadata']['name']
@@ -269,7 +269,7 @@ class EndpointsHandler(k8s_base.ResourceEventHandler):
                 self._lb_provider = (
                     config.CONF.kubernetes.endpoints_driver_octavia_provider)
 
-    def on_present(self, endpoints):
+    def on_present(self, endpoints, *args, **kwargs):
         ep_name = endpoints['metadata']['name']
         ep_namespace = endpoints['metadata']['namespace']
         if self._move_annotations_to_crd(endpoints):

--- a/kuryr_kubernetes/controller/handlers/loadbalancer.py
+++ b/kuryr_kubernetes/controller/handlers/loadbalancer.py
@@ -56,7 +56,7 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
         return utils.get_subnets_id_cidrs(
             self._drv_nodes_subnets.get_nodes_subnets())
 
-    def on_present(self, loadbalancer_crd):
+    def on_present(self, loadbalancer_crd, *args, **kwargs):
         if loadbalancer_crd.get('status', None) is None:
 
             kubernetes = clients.get_kubernetes_client()
@@ -124,7 +124,7 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
             return False
         return True
 
-    def on_finalize(self, loadbalancer_crd):
+    def on_finalize(self, loadbalancer_crd, *args, **kwargs):
         LOG.debug("Deleting the loadbalancer CRD")
 
         if loadbalancer_crd['status'] != {}:

--- a/kuryr_kubernetes/controller/handlers/machine.py
+++ b/kuryr_kubernetes/controller/handlers/machine.py
@@ -52,14 +52,14 @@ class MachineHandler(k8s_base.ResourceEventHandler):
                 # Had to be deleted in the meanwhile.
                 pass
 
-    def on_present(self, machine):
+    def on_present(self, machine, *args, **kwargs):
         effect = self.node_subnets_driver.add_node(machine)
         if effect:
             # If the change was meaningful we need to make sure all the NPs
             # are recalculated to get the new SG rules added.
             self._bump_nps()
 
-    def on_deleted(self, machine):
+    def on_deleted(self, machine, *args, **kwargs):
         effect = self.node_subnets_driver.delete_node(machine)
         if effect:
             # If the change was meaningful we need to make sure all the NPs

--- a/kuryr_kubernetes/controller/handlers/namespace.py
+++ b/kuryr_kubernetes/controller/handlers/namespace.py
@@ -71,7 +71,7 @@ class NamespaceHandler(k8s_base.ResourceEventHandler):
             except exceptions.K8sResourceNotFound:
                 LOG.debug('Kuryrnet object already deleted: %s', net_crd)
 
-    def on_present(self, namespace):
+    def on_present(self, namespace, *args, **kwargs):
         ns_labels = namespace['metadata'].get('labels', {})
         ns_name = namespace['metadata']['name']
         kns_crd = self._get_kns_crd(ns_name)

--- a/kuryr_kubernetes/controller/handlers/pod_label.py
+++ b/kuryr_kubernetes/controller/handlers/pod_label.py
@@ -47,7 +47,7 @@ class PodLabelHandler(k8s_base.ResourceEventHandler):
         self._drv_vif_pool.set_vif_driver()
         self._drv_lbaas = drivers.LBaaSDriver.get_instance()
 
-    def on_present(self, pod):
+    def on_present(self, pod, *args, **kwargs):
         if driver_utils.is_host_network(pod) or not self._has_vifs(pod):
             # NOTE(ltomasbo): The event will be retried once the vif handler
             # annotates the pod with the pod state.

--- a/kuryr_kubernetes/controller/handlers/policy.py
+++ b/kuryr_kubernetes/controller/handlers/policy.py
@@ -34,7 +34,7 @@ class NetworkPolicyHandler(k8s_base.ResourceEventHandler):
         self._drv_policy = drivers.NetworkPolicyDriver.get_instance()
         self.k8s = clients.get_kubernetes_client()
 
-    def on_present(self, policy):
+    def on_present(self, policy, *args, **kwargs):
         LOG.debug("Created or updated: %s", policy)
 
         self._drv_policy.ensure_network_policy(policy)
@@ -42,7 +42,7 @@ class NetworkPolicyHandler(k8s_base.ResourceEventHandler):
         # Put finalizer in if it's not there already.
         self.k8s.add_finalizer(policy, k_const.NETWORKPOLICY_FINALIZER)
 
-    def on_finalize(self, policy):
+    def on_finalize(self, policy, *args, **kwargs):
         LOG.debug("Finalizing policy %s", policy)
         if not self._drv_policy.release_network_policy(policy):
             # KNP was not found, so we need to finalize on our own.

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -65,7 +65,7 @@ class VIFHandler(k8s_base.ResourceEventHandler):
                 except k_exc.K8sResourceNotFound:
                     pass
 
-    def on_present(self, pod):
+    def on_present(self, pod, *args, **kwargs):
         if (driver_utils.is_host_network(pod) or
                 not self._is_pod_scheduled(pod)):
             # REVISIT(ivc): consider an additional configurable check that
@@ -118,7 +118,7 @@ class VIFHandler(k8s_base.ResourceEventHandler):
                               "KuryrPort CRD: %s", ex)
                 raise k_exc.ResourceNotReady(pod)
 
-    def on_finalize(self, pod):
+    def on_finalize(self, pod, *args, **kwargs):
         k8s = clients.get_kubernetes_client()
 
         try:

--- a/kuryr_kubernetes/handlers/k8s_base.py
+++ b/kuryr_kubernetes/handlers/k8s_base.py
@@ -78,30 +78,30 @@ class ResourceEventHandler(dispatch.EventConsumer, health.HealthHandler):
         obj = event.get('object')
         if 'MODIFIED' == event_type:
             if self._check_finalize(obj):
-                self.on_finalize(obj)
+                self.on_finalize(obj, *args, **kwargs)
                 return
-            self.on_modified(obj)
-            self.on_present(obj)
+            self.on_modified(obj, *args, **kwargs)
+            self.on_present(obj, *args, **kwargs)
         elif 'ADDED' == event_type:
             if self._check_finalize(obj):
-                self.on_finalize(obj)
+                self.on_finalize(obj, *args, **kwargs)
                 return
-            self.on_added(obj)
-            self.on_present(obj)
+            self.on_added(obj, *args, **kwargs)
+            self.on_present(obj, *args, **kwargs)
         elif 'DELETED' == event_type:
-            self.on_deleted(obj)
+            self.on_deleted(obj, *args, **kwargs)
 
-    def on_added(self, obj):
+    def on_added(self, obj, *args, **kwargs):
         pass
 
-    def on_present(self, obj):
+    def on_present(self, obj, *args, **kwargs):
         pass
 
-    def on_modified(self, obj):
+    def on_modified(self, obj, *args, **kwargs):
         pass
 
-    def on_deleted(self, obj):
+    def on_deleted(self, obj, *args, **kwargs):
         pass
 
-    def on_finalize(self, obj):
+    def on_finalize(self, obj, *args, **kwargs):
         pass

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrport.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrport.py
@@ -146,8 +146,10 @@ class TestKuryrPortHandler(test_base.TestCase):
 
             k8s.get.assert_called_once_with(self._pod_uri)
 
-        activate_vif.assert_has_calls([mock.call(self._vif1),
-                                       mock.call(self._vif2)])
+        activate_vif.assert_has_calls([mock.call(self._vif1, pod=self._pod,
+                                                 retry_info=mock.ANY),
+                                       mock.call(self._vif2, pod=self._pod,
+                                                 retry_info=mock.ANY)])
         update_crd.assert_called_once_with(self._kp, self._vifs)
 
     @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
@@ -182,8 +184,10 @@ class TestKuryrPortHandler(test_base.TestCase):
 
         kp.on_present(self._kp)
 
-        activate_vif.assert_has_calls([mock.call(self._vif1),
-                                       mock.call(self._vif2)])
+        activate_vif.assert_has_calls([mock.call(self._vif1, pod=mock.ANY,
+                                                 retry_info=mock.ANY),
+                                       mock.call(self._vif2, pod=mock.ANY,
+                                                 retry_info=mock.ANY)])
 
     @mock.patch('kuryr_kubernetes.controller.drivers.vif_pool.MultiVIFPool.'
                 'activate_vif')
@@ -328,8 +332,10 @@ class TestKuryrPortHandler(test_base.TestCase):
 
             k8s.get.assert_called_once_with(self._pod_uri)
 
-        activate_vif.assert_has_calls([mock.call(self._vif1),
-                                       mock.call(self._vif2)])
+        activate_vif.assert_has_calls([mock.call(self._vif1, pod=self._pod,
+                                                 retry_info=mock.ANY),
+                                       mock.call(self._vif2, pod=self._pod,
+                                                 retry_info=mock.ANY)])
         update_crd.assert_called_once_with(self._kp, self._vifs)
         create_sgr.assert_called_once_with(self._pod)
 

--- a/kuryr_kubernetes/tests/unit/handlers/test_retry.py
+++ b/kuryr_kubernetes/tests/unit/handlers/test_retry.py
@@ -95,7 +95,7 @@ class TestRetryHandler(test_base.TestCase):
 
         retry(event)
 
-        m_handler.assert_called_once_with(event)
+        m_handler.assert_called_once_with(event, retry_info=mock.ANY)
         m_sleep.assert_not_called()
 
     @mock.patch('itertools.count')
@@ -134,7 +134,8 @@ class TestRetryHandler(test_base.TestCase):
 
         retry(event)
 
-        m_handler.assert_has_calls([mock.call(event)] * attempts)
+        m_handler.assert_has_calls([mock.call(
+            event, retry_info=mock.ANY)] * attempts)
         m_sleep.assert_has_calls([
             mock.call(deadline, i + 1, failures[i])
             for i in range(len(failures))])
@@ -155,7 +156,8 @@ class TestRetryHandler(test_base.TestCase):
 
         self.assertRaises(_EX11, retry, event)
 
-        m_handler.assert_has_calls([mock.call(event)] * attempts)
+        m_handler.assert_has_calls([mock.call(
+            event, retry_info=mock.ANY)] * attempts)
         m_sleep.assert_has_calls([
             mock.call(deadline, i + 1, failures[i])
             for i in range(len(failures))])


### PR DESCRIPTION
Neutron should make a subport that is already attached to a trunk ACTIVE
immediately. Unfortunately there seems to be an OVN bug causing an event
triggering this to be lost, leaving the port in DOWN state forever. This
is a disaster for Kuryr, because we can't proceed to wire the pods in
such case.

This commit attempts to workaround this by making Kuryr reattach the
ports that are in DOWN state for more than 90 seconds after they're
plugged.

Change-Id: If9a3968d68dced588614cd5521d4a111e78d435f