### PR TITLE
Disable Flask logs of metrics calls

### DIFF
--- a/kuryr_kubernetes/cni/prometheus_exporter.py
+++ b/kuryr_kubernetes/cni/prometheus_exporter.py
@@ -46,6 +46,9 @@ class CNIPrometheusExporter(object):
         return flask.Response(collected_metric, mimetype='text/plain')
 
     def run(self):
+        # Disable obtrusive werkzeug logs.
+        logging.getLogger('werkzeug').setLevel(logging.WARNING)
+
         address = '::'
         try:
             LOG.info('Starting CNI Prometheus exporter')

--- a/kuryr_kubernetes/controller/managers/prometheus_exporter.py
+++ b/kuryr_kubernetes/controller/managers/prometheus_exporter.py
@@ -66,6 +66,9 @@ class ControllerPrometheusExporter(object):
         return ControllerPrometheusExporter.instance
 
     def run(self):
+        # Disable obtrusive werkzeug logs.
+        logging.getLogger('werkzeug').setLevel(logging.WARNING)
+
         address = '::'
         try:
             LOG.info('Starting Prometheus exporter')


### PR DESCRIPTION
We don't need to log every successful /metrics call on INFO level. This
commit switches the log level there to WARNING.