### PR TITLE
Add listeners, pools and members to must-gather

### DIFF
--- a/kuryr_kubernetes/cmd/gather_openstack_data.py
+++ b/kuryr_kubernetes/cmd/gather_openstack_data.py
@@ -42,6 +42,14 @@ def gather_network_data(os_net, project_id):
 def gather_loadbalancer_data(lbaas, project_id):
     print("Load Balancers:")
     pprint(list(lbaas.load_balancers()))
+    print("Listeners:")
+    pprint(list(lbaas.listeners()))
+    print("Pools:")
+    pools = list(lbaas.pools())
+    pprint(pools)
+    for pool in pools:
+        print(f"Pool {pool.id} members:")
+        pprint(list(lbaas.members(pool.id)))
     print("Load Balancer quota:")
     pprint(lbaas.get_quota(quota=project_id))
 


### PR DESCRIPTION
must-gather gets the listings of the OpenStack resources in the project
Kuryr has access to and saves them. Somehow we skipped the secondary
Octavia resources from there. This commit fixes it.

Change-Id: I433dae5e345bf707df7da7b58492e72090a5d6c5