### PR TITLE
Bug 1983107: Allow clean up of unused member

### DIFF
--- a/kuryr_kubernetes/controller/handlers/loadbalancer.py
+++ b/kuryr_kubernetes/controller/handlers/loadbalancer.py
@@ -389,7 +389,7 @@ class KuryrLoadBalancerHandler(k8s_base.ResourceEventHandler):
                     port['name'] = None
                 spec_ports[port['name']] = pool['id']
 
-        ep_slices = loadbalancer_crd['spec'].get('endpointSlices')
+        ep_slices = loadbalancer_crd['spec'].get('endpointSlices', [])
         # NOTE(maysams): As we don't support dual-stack, we assume
         # only one address is possible on the addresses field.
         current_targets = [(ep['addresses'][0],


### PR DESCRIPTION
When the endpoints subsets is empty and the
CR contains load balancer infomation on the
status the clean up of unused members should
be performed and right now it's not as we assume
subset is alwas present. This commit fixes the
issue by making empty list the default when
endpoint is not present.