### PR TITLE
Bug 1983107: Fix KLB conversion from annotations

### DIFF
--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -344,6 +344,8 @@ class EndpointsHandler(k8s_base.ResourceEventHandler):
             status = {}
         if not spec:
             spec = {'endpointSlices': epslices}
+        else:
+            spec['endpointSlices'] = epslices
 
         # NOTE(maysams): As the spec may already contain a
         # ports field from the Service, a new endpointslice


### PR DESCRIPTION
There's a corner case in conversion of Endpoints and Services
annotations into KuryrLoadBalancer CRDs in which the endpointSlices
field is ommitted causing a kuryr-controller restart. While it seems to
be harmless as after restart EndpointsHandler will kick in and add the
missing field, it's still worth to fix the migration.

This commit does so by making sure endpointSlices object is added to the
KuryrLoadbalancer spec.

Change-Id: I746c5e32f57491e94b7c04639bd9631f3a3fa6fb