### PR TITLE
Bug 1988379: Increase keystoneauth's connection pool size

### DIFF
--- a/kuryr_kubernetes/clients.py
+++ b/kuryr_kubernetes/clients.py
@@ -17,6 +17,7 @@ from functools import partial
 import ipaddress
 import os
 
+from keystoneauth1 import session as k_session
 from kuryr.lib import utils
 from openstack import connection
 from openstack import exceptions as os_exc
@@ -154,6 +155,14 @@ def handle_neutron_errors(method, *args, **kwargs):
 def setup_openstacksdk():
     auth_plugin = utils.get_auth_plugin('neutron')
     session = utils.get_keystone_session('neutron', auth_plugin)
+
+    # NOTE(mdulko): To get rid of warnings about connection pool being full
+    #               we need to "tweak" the keystoneauth's adapters increasing
+    #               the maximum pool size.
+    for scheme in list(session.session.adapters):
+        session.session.mount(scheme, k_session.TCPKeepAliveAdapter(
+            pool_maxsize=1000))
+
     # TODO(mdulko): To use Neutron's ability to do compare-and-swap updates we
     #               need to manually add support for inserting If-Match header
     #               into requests. At the moment we only need it for ports.


### PR DESCRIPTION
With Kuryr running up to 1000 greenthreads, the default urllib3 pool
size of 10 is way too little. This commit increases it on the
keystoneauth side, effectively setting it for the openstacksdk
connections.

Change-Id: I2ee06734ece04c2707f2ac95060bd451f0725089