### PR TITLE
Bug 1967540: Remove duplicated egress rule in knp

### DIFF
--- a/kuryr_kubernetes/controller/drivers/network_policy.py
+++ b/kuryr_kubernetes/controller/drivers/network_policy.py
@@ -587,7 +587,8 @@ class NetworkPolicyDriver(base.NetworkPolicyDriver):
                 if allowed_cidrs:
                     for cidr in allowed_cidrs:
                         rule = _create_sg_rule_body(direction, cidr=cidr)
-                        sg_rule_body_list.append(rule)
+                        if rule not in sg_rule_body_list:
+                            sg_rule_body_list.append(rule)
                         if direction == 'egress':
                             self._create_svc_egress_sg_rule(policy_namespace,
                                                             sg_rule_body_list)


### PR DESCRIPTION
## Problem Analysis

There are 2 egress rules. but spec is populated with 3:

```bash
  - description: Kuryr-Kubernetes NetPolicy SG rule
    direction: egress
    ethertype: IPv4
    id: fe784bb3-526f-497d-8160-93c9bd3c424b
    remote_ip_prefix: 172.30.0.0/15
    security_group_id: 96f53e4b-bcbb-41b3-8301-e7a00cbf9b27

# openstack security group show 96f53e4b-bcbb-41b3-8301-e7a00cbf9b27
+-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field           | Value                                                                                                                                                                                                                                                       |
+-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| created_at      | 2021-08-02T08:00:18Z                                                                                                                                                                                                                                        |
| description     | Kuryr-Kubernetes Network Policy test2/np-bz SG                                                                                                                                                                                                              |
| id              | 96f53e4b-bcbb-41b3-8301-e7a00cbf9b27                                                                                                                                                                                                                        |
| name            | sg-test2-np-bz                                                                                                                                                                                                                                              |
| project_id      | 7019cb3bfbf643958d6b7b12f3f0df86                                                                                                                                                                                                                            |
| revision_number | 9                                                                                                                                                                                                                                                           |
| rules           | created_at='2021-08-02T08:00:19Z', description='Kuryr-Kubernetes NetPolicy SG rule', direction='ingress', ethertype='IPv4', id='5e75d235-9309-4778-b1c4-e6c56423273d', remote_ip_prefix='10.128.120.0/23', updated_at='2021-08-02T08:00:19Z'                |
|                 | created_at='2021-08-02T08:00:20Z', description='Kuryr-Kubernetes NetPolicy SG rule', direction='ingress', ethertype='IPv4', id='636b8f50-f8a7-413b-95ce-b739bf465491', remote_ip_prefix='10.0.0.0/16', updated_at='2021-08-02T08:00:20Z'                    |
|                 | created_at='2021-08-02T08:00:21Z', description='Kuryr-Kubernetes NetPolicy SG rule', direction='egress', ethertype='IPv4', id='a94801b8-a17c-4bb9-a6fe-37ba504a2299', remote_ip_prefix='10.128.0.0/14', updated_at='2021-08-02T08:00:21Z'                   |
|                 | created_at='2021-08-02T08:00:20Z', description='Allow traffic from local namespace service demo2', direction='ingress', ethertype='IPv4', id='da1ac6fb-29fe-4510-a077-c7e9561a2c0f', remote_ip_prefix='172.30.11.159/32', updated_at='2021-08-02T08:00:20Z' |
|                 | created_at='2021-08-02T08:00:21Z', description='Kuryr-Kubernetes NetPolicy SG rule', direction='egress', ethertype='IPv4', id='fe784bb3-526f-497d-8160-93c9bd3c424b', remote_ip_prefix='172.30.0.0/15', updated_at='2021-08-02T08:00:21Z'                   |
| stateful        | None                                                                                                                                                                                                                                                        |
| tags            | ['openshiftClusterID=ostest-t7zlb']                                                                                                                                                                                                                         |
| updated_at      | 2021-08-02T08:00:21Z                                                                                                                                                                                                                                        |
+-----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```


Spec is populated in [https://github.com/zerodayz/kuryr-kubernetes-1/blob/6edfff43d49f7d724fa0c636633a541e785cc0c3/kuryr_kubernetes/controller/drivers/network_policy.py#L42-L65](https://github.com/zerodayz/kuryr-kubernetes-1/blob/6edfff43d49f7d724fa0c636633a541e785cc0c3/kuryr_kubernetes/controller/drivers/network_policy.py#L42-L65)

Added a little of extra logging:

```
_parse_sg_rules adding rule:
 {'sgRule': {'ethertype': 'IPv4', 'description': 'Kuryr-Kubernetes NetPolicy SG rule', 'direction': 'egress', 'remote_ip_prefix': '10.128.0.0/14'}}
 ===========
_create_svc_egress_sg_rule adding rule:
 {'sgRule': {'ethertype': 'IPv4', 'description': 'Kuryr-Kubernetes NetPolicy SG rule', 'direction': 'egress', 'remote_ip_prefix': '172.30.0.0/15'}}
 ===========
_parse_sg_rules adding rule:
 {'sgRule': {'ethertype': 'IPv4', 'description': 'Kuryr-Kubernetes NetPolicy SG rule', 'direction': 'egress', 'remote_ip_prefix': '172.30.0.0/15'}}
 ===========
```

So the rule is getting generated two times in this loop:
```
if allowed_cidrs:
    for cidr in allowed_cidrs:
        rule = _create_sg_rule_body(direction, cidr=cidr)
        sg_rule_body_list.append(rule)
        if direction == 'egress':
            self._create_svc_egress_sg_rule(policy_namespace,
                                            sg_rule_body_list)
```

Iterate `cidr` in `[10.128.0.0/14, 172.30.0.0/15]`

- First iteration of `10.128.0.0/14`
- Append rule `10.128.0.0/14`
- Enter `_create_svc_egress_sg_rule`
- `CONF.neutron_defaults.service_subnet` returns service_subnet id from `/etc/kuryr/kuryr.conf`
```bash
grep service_subnet /etc/kuryr/kuryr.conf
service_subnet = 85ba241b-4336-4b51-aa4a-f76704315786
```
And that subnet is 172.30.0.0/15
```bash
openstack subnet list | grep 85ba241b-4336-4b51-aa4a-f76704315786
| 85ba241b-4336-4b51-aa4a-f76704315786 | ostest-t7zlb-kuryr-service-subnet | ec4536bc-2f71-4e43-b258-18f8e40ea870 | 172.30.0.0/15
```
- Check if rule doesn't exist in `sg_rule_body_list`
- Append rule `172.30.0.0/15` from `service_subnet`
- Second iteration of `172.30.0.0/15`
- Append rule `172.30.0.0/15`
- Check if rule doesn't exist in `sg_rule_body_list`
- Return `[10.128.0.0/14, 172.30.0.0/15, 172.30.0.0/15]`

Looking at the master branch, we don't call the `_create_svc_egress_sg_rule`

```python
if allowed_cidrs:
    for cidr in allowed_cidrs:
        rule = _create_sg_rule_body(direction, cidr=cidr)
        sg_rule_body_list.append(rule)     
```

It seems there was big refactor of `NetworkPolicyHandler` in master, will discuss on tonight Bug Triage call but for now submitting this fix.

## Proposed Fix
As of now I can think of fixing it the way that we add a check before adding a rule.

```python
if allowed_cidrs:
    for cidr in allowed_cidrs:
        rule = _create_sg_rule_body(direction, cidr=cidr)
        if rule not in sg_rule_body_list:
            sg_rule_body_list.append(rule)
        if direction == 'egress':
            self._create_svc_egress_sg_rule(policy_namespace,
                                            sg_rule_body_list)
```

```bash
Every 1.0s: oc get knp/np-bz -o json | jq .spec.egressSgRules
Tue Aug  3 23:46:13 2021

[
  {
    "sgRule": {
      "description": "Kuryr-Kubernetes NetPolicy SG rule",
      "direction": "egress",
      "ethertype": "IPv4",
      "remote_ip_prefix": "10.128.0.0/14"
    }
  },
  {
    "sgRule": {
      "description": "Kuryr-Kubernetes NetPolicy SG rule",
      "direction": "egress",
      "ethertype": "IPv4",
      "remote_ip_prefix": "172.30.0.0/15"
    }
  },
  {
    "sgRule": {
      "description": "Kuryr-Kubernetes NetPolicy SG rule",
      "direction": "egress",
      "ethertype": "IPv4",
      "remote_ip_prefix": "172.30.0.0/15"
    }
  }
]
```

After a while we can see the duplicated rule is removed from KNP
```bash
Every 1.0s: oc get knp/np-bz -o json | jq .spec.egressSgRules
Tue Aug  3 23:46:37 2021

[
  {
    "sgRule": {
      "description": "Kuryr-Kubernetes NetPolicy SG rule",
      "direction": "egress",
      "ethertype": "IPv4",
      "remote_ip_prefix": "10.128.0.0/14"
    }
  },
  {
    "sgRule": {
      "description": "Kuryr-Kubernetes NetPolicy SG rule",
      "direction": "egress",
      "ethertype": "IPv4",
      "remote_ip_prefix": "172.30.0.0/15"
    }
  }
]
```