### PR TITLE
Switch dockerfiles to use Rocky's RDO

### DIFF
--- a/openshift-kuryr-cni-ci.Dockerfile
+++ b/openshift-kuryr-cni-ci.Dockerfile
@@ -14,13 +14,11 @@ ARG OSLO_LOCK_PATH=/var/kuryr-lock
 RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/built.repo
 
 # FIXME(dulek): Until I'll figure out how to get OpenStack repos here, we need this hack.
-RUN yum install --setopt=tsflags=nodocs -y \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-    && printf '[openstack-stein]\n\
-name=OpenStack Stein Repository\n\
-baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-stein/\n\
+RUN printf '[openstack-rocky]\n\
+name=OpenStack Rocky Repository\n\
+baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-rocky/\n\
 gpgcheck=0\n\
-enabled=1\n' >> /etc/yum.repos.d/rdo-stein.repo
+enabled=1\n' >> /etc/yum.repos.d/rdo-rocky.repo
 
 COPY --from=builder /go/bin/kuryr-cni /kuryr-cni
 

--- a/openshift-kuryr-controller-ci.Dockerfile
+++ b/openshift-kuryr-controller-ci.Dockerfile
@@ -7,13 +7,11 @@ ENV container=oci
 RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/built.repo
 
 # FIXME(dulek): Until I'll figure out how to get OpenStack repos here, we need this hack.
-RUN yum install --setopt=tsflags=nodocs -y \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-    && printf '[openstack-stein]\n\
-name=OpenStack Stein Repository\n\
-baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-stein/\n\
+RUN printf '[openstack-rocky]\n\
+name=OpenStack Rocky Repository\n\
+baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-rocky/\n\
 gpgcheck=0\n\
-enabled=1\n' >> /etc/yum.repos.d/rdo-stein.repo
+enabled=1\n' >> /etc/yum.repos.d/rdo-rocky.repo
 
 RUN yum install -y openshift-kuryr-controller \
  && yum clean all \


### PR DESCRIPTION
Apparently we should not use Stein but Rocky as that's how 3.11 Kuryr is
built elsewhere.

Change-Id: I56f48a9973591fda4272b8904bd5f97ff09c551b