### PR TITLE
Bug 2002171: remove port from trunk on _cleanup_leftover_ports

### DIFF
--- a/kuryr_kubernetes/controller/drivers/namespace_subnet.py
+++ b/kuryr_kubernetes/controller/drivers/namespace_subnet.py
@@ -116,26 +116,7 @@ class NamespacePodSubnetDriver(default_subnet.DefaultPodSubnetDriver):
             leftover_ports = c_utils.get_ports_by_attrs(status='DOWN',
                                                         network_id=net_id)
             for leftover_port in leftover_ports:
-                try:
-                    neutron.delete_port(leftover_port['id'])
-                except n_exc.PortNotFoundClient:
-                    LOG.debug("Port already deleted.")
-                except n_exc.NeutronClientException as e:
-                    if "currently a subport for trunk" in str(e):
-                        LOG.warning("Port %s is in DOWN status but still "
-                                    "associated to a trunk. This should not "
-                                    "happen. Trying to delete it from the "
-                                    "trunk.", leftover_port['id'])
-                        # Get the trunk_id from the error message
-                        trunk_id = (
-                            str(e).split('trunk')[1].split('.')[0].strip())
-                        neutron.trunk_remove_subports(
-                            trunk_id, {'sub_ports': [
-                                {'port_id': leftover_port['id']}]})
-                    else:
-                        LOG.exception("Unexpected error deleting leftover "
-                                      "port %s. Skiping it and continue with "
-                                      "the other rest.", leftover_port['id'])
+                c_utils.delete_port(leftover_port)
             raise exceptions.ResourceNotReady(net_id)
         except n_exc.NeutronClientException:
             LOG.exception("Error deleting network %s.", net_id)

--- a/kuryr_kubernetes/controller/drivers/vif_pool.py
+++ b/kuryr_kubernetes/controller/drivers/vif_pool.py
@@ -454,7 +454,7 @@ class BaseVIFPool(base.VIFPoolDriver):
         else:
             for port in existing_ports:
                 if not port.get('binding:host_id'):
-                    neutron.delete_port(port['id'])
+                    c_utils.delete_port(port)
 
 
 class NeutronVIFPool(BaseVIFPool):


### PR DESCRIPTION
This prevents Kuryr Controller from CrashLoopBackoff in unexpected case where the port is still part of the trunk during `_cleanup_leftover_ports`