### PR TITLE
Bug 2002548: Fix health checks on large scale environments

### DIFF
--- a/kuryr_kubernetes/clients.py
+++ b/kuryr_kubernetes/clients.py
@@ -42,6 +42,10 @@ def get_loadbalancer_client():
     return get_openstacksdk().load_balancer
 
 
+def get_network_client():
+    return get_openstacksdk().network
+
+
 def get_kubernetes_client():
     return _clients[_KUBERNETES_CLIENT]
 

--- a/kuryr_kubernetes/controller/handlers/namespace.py
+++ b/kuryr_kubernetes/controller/handlers/namespace.py
@@ -188,17 +188,12 @@ class NamespaceHandler(k8s_base.ResourceEventHandler):
 
     @MEMOIZE
     def _check_quota(self, quota):
-        neutron = clients.get_neutron_client()
-        resources = {'subnet': neutron.list_subnets,
-                     'network': neutron.list_networks,
-                     'security_group': neutron.list_security_groups}
+        resources = ('subnets', 'networks', 'security_groups')
 
-        for resource, neutron_func in resources.items():
+        for resource in resources:
             resource_quota = quota[resource]
-            resource_name = resource + 's'
             if utils.has_limit(resource_quota):
-                if not utils.is_available(resource_name, resource_quota,
-                                          neutron_func):
+                if not utils.is_available(resource, resource_quota):
                     return False
         return True
 

--- a/kuryr_kubernetes/controller/handlers/policy.py
+++ b/kuryr_kubernetes/controller/handlers/policy.py
@@ -141,11 +141,8 @@ class NetworkPolicyHandler(k8s_base.ResourceEventHandler):
 
     @MEMOIZE
     def _check_quota(self, quota):
-        neutron = clients.get_neutron_client()
-        sg_quota = quota['security_group']
-        sg_func = neutron.list_security_groups
-        if utils.has_limit(sg_quota):
-            return utils.is_available('security_groups', sg_quota, sg_func)
+        if utils.has_limit(quota.security_groups):
+            return utils.is_available('security_groups', quota.security_groups)
         return True
 
     def _is_service_affected(self, service, affected_pods):

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -212,11 +212,10 @@ class VIFHandler(k8s_base.ResourceEventHandler):
 
     @MEMOIZE
     def is_ready(self, quota):
-        neutron = clients.get_neutron_client()
-        port_quota = quota['port']
-        port_func = neutron.list_ports
-        if utils.has_limit(port_quota):
-            return utils.is_available('ports', port_quota, port_func)
+        if (utils.has_limit(quota.ports) and
+                not utils.is_available('ports', quota.ports)):
+            LOG.error('Marking VIFHandler as not ready.')
+            return False
         return True
 
     @staticmethod

--- a/kuryr_kubernetes/controller/managers/health.py
+++ b/kuryr_kubernetes/controller/managers/health.py
@@ -59,9 +59,9 @@ class HealthServer(object):
         self.headers = {'Connection': 'close'}
 
     def _components_ready(self):
-        neutron = clients.get_neutron_client()
+        neutron = clients.get_network_client()
         project_id = config.CONF.neutron_defaults.project
-        quota = neutron.show_quota(project_id).get('quota')
+        quota = neutron.get_quota(quota=project_id, details=True)
 
         for component in self._registry:
             if not component.is_ready(quota):

--- a/kuryr_kubernetes/tests/unit/controller/managers/test_health.py
+++ b/kuryr_kubernetes/tests/unit/controller/managers/test_health.py
@@ -23,15 +23,51 @@ from oslo_config import cfg as oslo_cfg
 def get_quota_obj():
     return {
         'quota': {
-            'subnet': 100,
-            'network': 100,
-            'floatingip': 50,
-            'subnetpool': -1,
-            'security_group_rule': 100,
-            'security_group': 10,
-            'router': 10,
-            'rbac_policy': 10,
-            'port': 500
+            'subnet': {
+                'used': 50,
+                'limit': 100,
+                'reserved': 0
+            },
+            'network': {
+                'used': 50,
+                'limit': 100,
+                'reserved': 0
+            },
+            'floatingip': {
+                'used': 25,
+                'limit': 50,
+                'reserved': 0
+            },
+            'subnetpool': {
+                'used': 0,
+                'limit': -1,
+                'reserved': 0
+            },
+            'security_group_rule': {
+                'used': 50,
+                'limit': 100,
+                'reserved': 0
+            },
+            'security_group': {
+                'used': 5,
+                'limit': 10,
+                'reserved': 0
+            },
+            'router': {
+                'used': 5,
+                'limit': 10,
+                'reserved': 0
+            },
+            'rbac_policy': {
+                'used': 5,
+                'limit': 10,
+                'reserved': 0
+            },
+            'port': {
+                'used': 250,
+                'limit': 500,
+                'reserved': 0
+            }
         }
     }
 
@@ -144,8 +180,8 @@ class TestHealthServer(base.TestCase):
 
     @mock.patch.object(_TestHandler, 'is_ready')
     def test__components_ready(self, m_status):
-        neutron = self.useFixture(k_fix.MockNeutronClient()).client
-        neutron.show_quota.return_value = get_quota_obj()
+        neutron = self.useFixture(k_fix.MockNetworkClient()).client
+        neutron.get_quota.return_value = get_quota_obj()
         self.srv._registry = [_TestHandler()]
         m_status.return_value = True
 
@@ -153,12 +189,12 @@ class TestHealthServer(base.TestCase):
 
         m_status.assert_called_once()
         self.assertEqual(resp, True)
-        neutron.show_quota.assert_called_once()
+        neutron.get_quota.assert_called_once()
 
     @mock.patch.object(_TestHandler, 'is_ready')
     def test__components_ready_error(self, m_status):
-        neutron = self.useFixture(k_fix.MockNeutronClient()).client
-        neutron.show_quota.return_value = get_quota_obj()
+        neutron = self.useFixture(k_fix.MockNetworkClient()).client
+        neutron.get_quota.return_value = get_quota_obj()
         self.srv._registry = [_TestHandler()]
         m_status.return_value = False
 
@@ -166,7 +202,7 @@ class TestHealthServer(base.TestCase):
 
         m_status.assert_called_once()
         self.assertEqual(resp, False)
-        neutron.show_quota.assert_called_once()
+        neutron.get_quota.assert_called_once()
 
     @mock.patch.object(_TestHandler, 'is_alive')
     def test_liveness(self, m_status):

--- a/kuryr_kubernetes/tests/unit/kuryr_fixtures.py
+++ b/kuryr_kubernetes/tests/unit/kuryr_fixtures.py
@@ -41,3 +41,11 @@ class MockLBaaSClient(fixtures.Fixture):
         self.useFixture(fixtures.MockPatch(
             'kuryr_kubernetes.clients.get_loadbalancer_client',
             lambda: self.client))
+
+
+class MockNetworkClient(fixtures.Fixture):
+    def _setUp(self):
+        self.client = mock.Mock()
+        self.useFixture(fixtures.MockPatch(
+            'kuryr_kubernetes.clients.get_network_client',
+            lambda: self.client))

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -219,15 +219,18 @@ def extract_pod_annotation(annotation):
 
 def has_limit(quota):
     NO_LIMIT = -1
-    return quota != NO_LIMIT
+    return quota['limit'] != NO_LIMIT
 
 
-def is_available(resource, resource_quota, neutron_func):
-    qnt_resources = len(neutron_func().get(resource))
-    availability = resource_quota - qnt_resources
+def is_available(resource, resource_quota):
+    availability = resource_quota['limit'] - resource_quota['used']
     if availability <= 0:
-        LOG.error("Quota exceeded for resource: %s", resource)
+        LOG.error("Neutron quota exceeded for %s. Used %d out of %d limit.",
+                  resource, resource_quota['used'], resource_quota['limit'])
         return False
+    elif availability <= 3:
+        LOG.warning("Neutron quota low for %s. Used %d out of %d limit.",
+                    resource, resource_quota['used'], resource_quota['limit'])
     return True
 
 


### PR DESCRIPTION
With large scale environments >3k ports, the health checks fails due to the slowness in API response from OpenStack.

This only changes the checks so that they use quota client instead.