### PR TITLE
Bug 2002909: dont block kuryr if one subnet runs out of IPs

### DIFF
--- a/kuryr_kubernetes/exceptions.py
+++ b/kuryr_kubernetes/exceptions.py
@@ -22,6 +22,18 @@ class IntegrityError(RuntimeError):
     pass
 
 
+class VIFPoolNotReady(Exception):
+    def __init__(self, resource):
+        super(VIFPoolNotReady, self).__init__("VIF Pool not ready %s: " %
+                                              (resource,))
+
+
+class VIFPoolEmpty(Exception):
+    def __init__(self, resource):
+        super(VIFPoolEmpty, self).__init__("VIF Pool empty %s: " %
+                                           (resource,))
+
+
 class ResourceNotReady(Exception):
     def __init__(self, resource):
         super(ResourceNotReady, self).__init__("Resource not ready: %r"

--- a/kuryr_kubernetes/handlers/retry.py
+++ b/kuryr_kubernetes/handlers/retry.py
@@ -77,7 +77,10 @@ class Retry(base.EventHandler):
             try:
                 self._handler(event)
                 break
-            except n_exc.OverQuotaClient:
+            except (n_exc.OverQuotaClient,
+                    n_exc.IpAddressGenerationFailureClient,
+                    exceptions.VIFPoolNotReady,
+                    exceptions.VIFPoolEmpty):
                 with excutils.save_and_reraise_exception() as ex:
                     if self._sleep(deadline, attempt, ex.value):
                         ex.reraise = False

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
@@ -551,7 +551,7 @@ class NeutronVIFPool(test_base.TestCase):
             pool_key: {tuple(security_groups): collections.deque([])}}
         m_driver._last_update = {pool_key: {tuple(security_groups): 1}}
 
-        self.assertRaises(exceptions.ResourceNotReady, cls._get_port_from_pool,
+        self.assertRaises(exceptions.VIFPoolEmpty, cls._get_port_from_pool,
                           m_driver, pool_key, pod, subnets,
                           tuple(security_groups))
 
@@ -1095,7 +1095,7 @@ class NestedVIFPool(test_base.TestCase):
             pool_key: {tuple(security_groups): collections.deque([])}}
         m_driver._last_update = {pool_key: {tuple(security_groups): 1}}
 
-        self.assertRaises(exceptions.ResourceNotReady, cls._get_port_from_pool,
+        self.assertRaises(exceptions.VIFPoolEmpty, cls._get_port_from_pool,
                           m_driver, pool_key, pod, subnets, tuple(
                               security_groups))
 


### PR DESCRIPTION
## Problem description

It seems that `eventlet.spawn` swallows the Exception from neutron and the `kuryr_kubernetes/handlers/retry.py` always fails with `ResourceNotReady` exception

```python
        try:
            return self._get_port_from_pool(pool_key, pod, subnets,
                                            tuple(sorted(security_groups)))
        except exceptions.ResourceNotReady:
            LOG.warning("Ports pool does not have available ports!")
            eventlet.spawn(self._populate_pool, pool_key, pod, subnets,
                           tuple(sorted(security_groups)))
            raise
```

This means that the following retry will always raise an exception `ResourceNotReady` regardless neutron

```python
            try:
                self._handler(event)
                break
            except n_exc.OverQuotaClient:
                with excutils.save_and_reraise_exception() as ex:
                    if self._sleep(deadline, attempt, ex.value):
                        ex.reraise = False
            except self._exceptions:
                with excutils.save_and_reraise_exception() as ex:
                    if self._sleep(deadline, attempt, ex.value):
                        ex.reraise = False
                    else:
                        LOG.debug('Report handler unhealthy %s', self._handler)
                        self._handler.set_liveness(alive=False)
            except Exception:
                LOG.exception('Report handler unhealthy %s', self._handler)
                self._handler.set_liveness(alive=False)
                raise
```

Thus ignoring `OverQuotaClient` or any other exception.

Without this patch:

```
2021-09-10 03:56:06.167 4487 DEBUG kuryr_kubernetes.handlers.retry [-] Handler VIFHandler failed (attempt 9; ResourceNotReady: Resource not ready: 
```

With this patch:

```
2021-09-10 16:34:17.581 6985 DEBUG kuryr_kubernetes.handlers.retry [-] Handler VIFHandler failed (attempt 8; IpAddressGenerationFailureClient: No more IP addresses available on network 5dd1dacd-e11e-47d2-ace7-20b497384092.
```

I run into this when I wanted to exclude new exception `IpAddressGenerationFailureClient` because it doesn't make 
much sense to restart Kuryr controller on no more IP addresses available in the pool, since Kuryr doesn't allow 
update of neutron subnet.

In case of large Environment, the kuryr startup can take 2+ minutes during which Kuryr controller is unable to handle any updates.
Then VIF Handler will fail liveness probe in ~8 minutes (after ~10 attempts, ~500s) and the entire process repeats.

The sysadmins must be already aware of the issue as their developers are unable to create any new pods in the namespace.

Well Kuryr controller still works as there is no problem with is as such. We delay some handlers being processed and more pressure on OpenStack.

The `/alive` will block `VIFHandler` and it may take time before `K8s` actually trigger the restart of the container.

This extends the time when the Kuryr controller is unusable and creates more headaches to system admins working with Kuryr.

## Reproducer

```bash
# Check original range
openstack subnet show ns/momo-subnet -f value -c allocation_pools
192.168.3.2-192.168.3.62
# Update the subnet allocation pool
neutron subnet-update --allocation-pool start=192.168.3.2,end=192.168.3.4 ns/momo-subnet
# Check the updated range
openstack subnet show ns/momo-subnet -f value -c allocation_pools
192.168.3.2-192.168.3.4
```

Scale the pods beyond the range
```bash
oc scale deployment echo --replicas=25
```

Check the pods
```bash
$ oc get pods
NAME                    READY     STATUS              RESTARTS   AGE
echo-6b477b8fd7-26vjw   0/1       ContainerCreating   0          12m
echo-6b477b8fd7-49hnf   0/1       ContainerCreating   0          12m
echo-6b477b8fd7-5jbvk   1/1       Running             0          12m
echo-6b477b8fd7-6svm9   1/1       Running             0          12m
echo-6b477b8fd7-7wln8   1/1       Running             0          15d
echo-6b477b8fd7-9wvp2   1/1       Running             0          12m
echo-6b477b8fd7-bpd7f   1/1       Running             0          13m
echo-6b477b8fd7-cms48   0/1       ContainerCreating   0          12m
echo-6b477b8fd7-d64zm   1/1       Running             0          13m
echo-6b477b8fd7-dtfsq   1/1       Running             0          12m
echo-6b477b8fd7-f7zqg   1/1       Running             0          13m
echo-6b477b8fd7-g6tw4   0/1       ContainerCreating   0          12m
echo-6b477b8fd7-jcqcf   1/1       Running             0          12m
echo-6b477b8fd7-jpbbh   1/1       Running             0          12m
echo-6b477b8fd7-k2kf8   0/1       ContainerCreating   0          12m
echo-6b477b8fd7-l775r   0/1       ContainerCreating   0          12m
echo-6b477b8fd7-lbjrr   1/1       Running             0          12m
echo-6b477b8fd7-n8tq2   1/1       Running             0          12m
echo-6b477b8fd7-nlsbr   1/1       Running             0          12m
echo-6b477b8fd7-s96m2   1/1       Running             0          12m
echo-6b477b8fd7-vrchb   0/1       ContainerCreating   0          12m
echo-6b477b8fd7-wgjnj   0/1       ContainerCreating   0          12m
echo-6b477b8fd7-wsvz6   0/1       ContainerCreating   0          12m
echo-6b477b8fd7-xdph2   1/1       Running             0          12m
echo-6b477b8fd7-zxztf   0/1       ContainerCreating   0          12m
```

We can see that neutron fails to create more ports
```bash
2021-09-10 03:50:54.354 4487 ERROR kuryr_kubernetes.controller.drivers.nested_vlan_vif [-] Error creating bulk ports:

IpAddressGenerationFailureClient: 
No more IP addresses available on network 5dd1dacd-e11e-47d2-ace7-20b497384092.

2021-09-10 03:49:29.352 Traceback (most recent call last):
2021-09-10 03:49:29.352   File "/home/cloud-user/stack/kuryr-kubernetes/kuryr_kubernetes/controller/drivers/nested_vlan_vif.py", line 84, in request_vifs
2021-09-10 03:49:29.352     ports = neutron.create_port(bulk_port_rq).get('ports')
2021-09-10 03:49:29.352   File "/home/cloud-user/stack/kuryr-kubernetes/.venv/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 794, in create_port
2021-09-10 03:49:29.352     return self.post(self.ports_path, body=body)
2021-09-10 03:49:29.352   File "/home/cloud-user/stack/kuryr-kubernetes/.venv/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 359, in post
2021-09-10 03:49:29.352     headers=headers, params=params)
2021-09-10 03:49:29.352   File "/home/cloud-user/stack/kuryr-kubernetes/.venv/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 294, in do_request
2021-09-10 03:49:29.352     self._handle_fault_response(status_code, replybody, resp)
2021-09-10 03:49:29.352   File "/home/cloud-user/stack/kuryr-kubernetes/.venv/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 269, in _handle_fault_response
2021-09-10 03:49:29.352     exception_handler_v20(status_code, error_body)
2021-09-10 03:49:29.352   File "/home/cloud-user/stack/kuryr-kubernetes/.venv/lib/python2.7/site-packages/neutronclient/v2_0/client.py", line 93, in exception_handler_v20
2021-09-10 03:49:29.352     request_ids=request_ids)
2021-09-10 03:49:29.352 IpAddressGenerationFailureClient: No more IP addresses available on network 5dd1dacd-e11e-47d2-ace7-20b497384092.
```

And we can see the VIF Handler fails eventually
```bash
2021-09-10 03:56:06.167 4487 DEBUG kuryr_kubernetes.handlers.retry [-] Handler VIFHandler failed (attempt 9; ResourceNotReady: Resource not ready: ...)
2021-09-10 03:56:06.168 4487 DEBUG kuryr_kubernetes.handlers.retry [-] Report handler unhealthy VIFHandler __call__ /home/cloud-user/stack/kuryr-kubernetes/kuryr_kubernetes/handlers/retry.py:89
```

And liveness is set to `False`
```bash
curl -v 127.0.0.1:8082/alive
* About to connect() to 127.0.0.1 port 8082 (#0)
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8082 (#0)
> GET /alive HTTP/1.1
> User-Agent: curl/7.29.0
> Host: 127.0.0.1:8082
> Accept: */*
>
* HTTP 1.0, assume close after body
< HTTP/1.0 500 INTERNAL SERVER ERROR
< Connection: close
< Content-Type: text/html; charset=utf-8
< Content-Length: 0
< Server: Werkzeug/0.14.1 Python/2.7.5
< Date: Fri, 10 Sep 2021 07:56:29 GMT
<
* Closing connection 0
```
