### PR TITLE
Bug 2005355: tox tests: Pin virtualenv to 20.7.2

### DIFF
--- a/openshift-kuryr-tester-rhel8.Dockerfile
+++ b/openshift-kuryr-tester-rhel8.Dockerfile
@@ -5,7 +5,7 @@ ENV container=oci
 RUN yum install -y python3-devel python3-pbr python3-pip \
  && yum clean all \
  && rm -rf /var/cache/yum \
- && pip3 install tox
+ && pip3 install tox "virtualenv==20.7.2"
 
 LABEL \
         io.k8s.description="This is a component of OpenShift Container Platform and provides a testing container for Kuryr service." \


### PR DESCRIPTION
virtualenv 20.8.0 pulls in setuptools 58 which is incompatible with some
of our deps. This commit pins virtualenv to earlier version to make sure
unit tests and pep8 works.