### PR TITLE
Force pip to use distro's CA certs

### DIFF
--- a/openshift-kuryr-tester.Dockerfile
+++ b/openshift-kuryr-tester.Dockerfile
@@ -7,6 +7,9 @@ RUN yum update -y \
  && yum clean all \
  && rm -rf /var/cache/yum \
  && pip install -U pip==20.3.3 \
+ && pip config --global set global.cert /etc/ssl/certs/ca-bundle.crt \
+ # need to make sure up to date certs are used by pip as apparently pip uses its
+ # own certificates and those got outdated as we're pinning pip to an old version that still has Python 2 support.
  && pip install "more-itertools<6.0.0" tox
  # more-itertools 6.0.0 drops support for Python 2.7, so we need to ensure we have older version.
 


### PR DESCRIPTION
Due to Let's Encrypt CA certificate expiring recently we're hitting
issues when pip in kuryr-tester is trying to reach opendev.org to fetch
global upper-constraints.txt file. Apparently pip uses it's own CA
certificates and those got expired.

This commit attempts to solve it by forcing pip to use system's CA
certificates by modifying its global configuration.