### PR TITLE
DNM: Ensure KLB is updated

### DIFF
--- a/kuryr_kubernetes/controller/drivers/lbaasv2.py
+++ b/kuryr_kubernetes/controller/drivers/lbaasv2.py
@@ -701,16 +701,13 @@ class LBaaSv2Driver(base.LBaaSDriver):
         return result
 
     def _ensure_loadbalancer(self, loadbalancer):
-        try:
-            result = self._create_loadbalancer(loadbalancer)
-            LOG.debug("Created %(obj)s", {'obj': result})
-            return result
-        except os_exc.HttpException as e:
-            if e.status_code not in OKAY_CODES:
-                raise
         result = self._find_loadbalancer(loadbalancer)
         if result:
             LOG.debug("Found %(obj)s", {'obj': result})
+            return result
+
+        result = self._create_loadbalancer(loadbalancer)
+        LOG.debug("Created %(obj)s", {'obj': result})
         return result
 
     def _ensure_provisioned(self, loadbalancer, obj, create, find,


### PR DESCRIPTION
We're moving this because we discovered that Octavia will not always
raise Conflict if you create an LB with the same IP.

If no VIP port got created for an LB, then Octavia will not have any
issue with creating another LB with the same IP.

Closes-Bug: 1947809

Change-Id: I26b911b30403c7ea5a35706b2fc80af499e91330
(cherry picked from commit 21871b5d7491ad40b7d15bd6d51fbca31f49767e)