### PR TITLE
Bug 2019721: Update TOX_CONSTRAINTS_FILE for stable/xena

### DIFF
--- a/cni.Dockerfile
+++ b/cni.Dockerfile
@@ -7,7 +7,7 @@ RUN go build -o /go/bin/kuryr-cni ./kuryr_cni
 FROM centos:8
 LABEL authors="Antoni Segura Puimedon<toni@kuryr.org>, Michał Dulko<mdulko@redhat.com>"
 
-ARG UPPER_CONSTRAINTS_FILE="https://releases.openstack.org/constraints/upper/master"
+ARG UPPER_CONSTRAINTS_FILE="https://releases.openstack.org/constraints/upper/xena"
 ARG OSLO_LOCK_PATH=/var/kuryr-lock
 ARG PKG_YUM_REPO=https://rdoproject.org/repos/openstack-ussuri/rdo-release-ussuri-0.el8.noarch.rpm
 

--- a/controller.Dockerfile
+++ b/controller.Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 LABEL authors="Antoni Segura Puimedon<toni@kuryr.org>, Michał Dulko<mdulko@redhat.com>"
 
-ARG UPPER_CONSTRAINTS_FILE="https://releases.openstack.org/constraints/upper/master"
+ARG UPPER_CONSTRAINTS_FILE="https://releases.openstack.org/constraints/upper/xena"
 
 RUN yum upgrade -y \
     && yum install -y epel-release \

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ passenv = HOME
 setenv = VIRTUAL_ENV={envdir}
 usedevelop = True
 install_command = pip install {opts} {packages}
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/xena}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 whitelist_externals = sh
@@ -48,7 +48,7 @@ commands =
 
 [testenv:docs]
 basepython = python3
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/xena}
        -r{toxinidir}/doc/requirements.txt
 commands = sphinx-build -W -b html doc/source doc/build/html
 


### PR DESCRIPTION
Update the URL to the upper-constraints file to point to the redirect
rule on releases.openstack.org so that anyone working on this branch
will switch to the correct upper-constraints list automatically when
the requirements repository branches.

Until the requirements repository has as stable/xena branch, tests will
continue to use the upper-constraints list on master.

Change-Id: Icd3318bd9e0cbf25894ab2849223f19c53447654