### PR TITLE
Bug 2020664: Ensure DOWN subports are cleaned up

### DIFF
--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -691,6 +691,7 @@ def delete_port(leftover_port):
         # doesn't raise an exception if port doesn't exists nor
         # return any information.
         os_net.delete_port(leftover_port.id)
+        return True
     except os_exc.SDKException as e:
         if "currently a subport for trunk" in str(e):
             if leftover_port.status == "DOWN":
@@ -711,6 +712,7 @@ def delete_port(leftover_port):
                     leftover_port.id, trunk_id)
             try:
                 os_net.delete_port(leftover_port.id)
+                return True
             except os_exc.SDKException:
                 LOG.exception("Unexpected error deleting "
                               "leftover port %s. Skipping it "
@@ -721,3 +723,4 @@ def delete_port(leftover_port):
                           "port %s. Skipping it and "
                           "continue with the other "
                           "rest.", leftover_port.id)
+    return False

--- a/kuryr_kubernetes/controller/drivers/vif_pool.py
+++ b/kuryr_kubernetes/controller/drivers/vif_pool.py
@@ -551,12 +551,8 @@ class BaseVIFPool(base.VIFPoolDriver, metaclass=abc.ABCMeta):
                     del self._existing_vifs[subport.id]
                 except KeyError:
                     LOG.debug('Port %s is not in the ports list.', subport.id)
-                try:
-                    os_net.delete_port(subport.id)
-                except os_exc.SDKException:
-                    LOG.debug("Problem deleting leftover port %s. "
-                              "Skipping.", subport.id)
-                else:
+                port_deleted = c_utils.delete_port(subport)
+                if port_deleted:
                     previous_ports_to_remove.remove(subport.id)
 
             # normal ports, or subports not yet attached


### PR DESCRIPTION
Due to a known Neutron issue it's possible
to have subports with DOWN status and upon
controller restart those subports with are
not taken into account when repopulating the
pools resulting in leftovers. This commit
ensures nodes_ports_cleanup thread detach the
Port from the Trunk and remove it from the
Trunk.

Change-Id: If106637c81a5566d7bea00561f5cf1b381f97f23