### PR TITLE
Bug 2019886: Improve retrieval of Trunks info

### DIFF
--- a/kuryr_kubernetes/controller/drivers/neutron_vif.py
+++ b/kuryr_kubernetes/controller/drivers/neutron_vif.py
@@ -111,7 +111,8 @@ class NeutronPodVIFDriver(base.PodVIFDriver):
 
     def update_vif_sgs(self, pod, security_groups):
         os_net = clients.get_network_client()
-        vifs = utils.get_vifs(pod)
+        kp = utils.get_kuryrport(pod)
+        vifs = utils.get_vifs(kp)
         if vifs:
             # NOTE(ltomasbo): It just updates the default_vif security group
             port_id = vifs[constants.DEFAULT_IFNAME].id

--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -71,8 +71,7 @@ def get_kuryrport(pod):
         return None
 
 
-def get_vifs(pod):
-    kp = get_kuryrport(pod)
+def get_vifs(kp):
     try:
         return {k: objects.base.VersionedObject.obj_from_primitive(v['vif'])
                 for k, v in kp['status']['vifs'].items()}

--- a/kuryr_kubernetes/controller/drivers/vif_pool.py
+++ b/kuryr_kubernetes/controller/drivers/vif_pool.py
@@ -296,9 +296,9 @@ class BaseVIFPool(base.VIFPoolDriver, metaclass=abc.ABCMeta):
         kubernetes = clients.get_kubernetes_client()
         in_use_ports = []
         networks = {}
-        running_pods = kubernetes.get(constants.K8S_API_BASE + '/pods')
-        for pod in running_pods['items']:
-            vifs = c_utils.get_vifs(pod)
+        kuryr_ports = kubernetes.get(constants.K8S_API_CRD_KURYRPORTS)
+        for kp in kuryr_ports['items']:
+            vifs = c_utils.get_vifs(kp)
             for data in vifs.values():
                 in_use_ports.append(data.id)
                 networks[data.network.id] = data.network
@@ -434,10 +434,9 @@ class BaseVIFPool(base.VIFPoolDriver, metaclass=abc.ABCMeta):
                         # getting the Network and Subnet info from
                         # Network defined on an existing KuryrPort CR.
                         # This assumes only one Subnet exists per Network.
-                        if in_use_networks.get(port.network_id):
-                            subnets[subnet_id] = {
-                                subnet_id: in_use_networks.get(
-                                    port.network_id)}
+                        network = in_use_networks.get(port.network_id)
+                        if network:
+                            subnets[subnet_id] = {subnet_id: network}
                         else:
                             subnets[subnet_id] = {
                                 subnet_id: utils.get_subnet(subnet_id)}

--- a/kuryr_kubernetes/controller/handlers/pod_label.py
+++ b/kuryr_kubernetes/controller/handlers/pod_label.py
@@ -107,8 +107,9 @@ class PodLabelHandler(k8s_base.ResourceEventHandler):
 
     def _has_vifs(self, pod):
         try:
-            kp = driver_utils.get_vifs(pod)
-            vifs = kp['status']['vifs']
+            kp = driver_utils.get_kuryrport(pod)
+            cr_vifs = driver_utils.get_vifs(kp)
+            vifs = cr_vifs['status']['vifs']
             LOG.debug("Pod have associated KuryrPort with vifs: %s", vifs)
         except KeyError:
             return False


### PR DESCRIPTION
Right now the in use Ports info is retrieved
by looking for the Pods and then for each
KuryrPort correponding to the specific Pod,
which can increase the time to recover precreated
Ports upon restart. This commit fixes the issue
by collecting all the KuryrPorts at once.