### PR TITLE
Bug 2022722: Make completed Pods Ports reusable

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrport.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrport.py
@@ -146,7 +146,8 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
                 raise
             return
 
-        if ('deletionTimestamp' not in pod['metadata']):
+        if ('deletionTimestamp' not in pod['metadata'] and
+                not utils.is_pod_completed(pod)):
             # NOTE(gryf): Ignore deleting KuryrPort, since most likely it was
             # removed manually, while we need vifs for corresponding pod
             # object which apperantely is still running.

--- a/kuryr_kubernetes/tests/unit/test_utils.py
+++ b/kuryr_kubernetes/tests/unit/test_utils.py
@@ -488,3 +488,15 @@ class TestUtils(test_base.TestCase):
         sub = utils.get_subnet_id(**filters)
         m_net.subnets.assert_called_with(**filters)
         self.assertIsNone(sub)
+
+    def test_is_pod_completed_pending(self):
+        self.assertFalse(utils.is_pod_completed({'status': {'phase':
+                         k_const.K8S_POD_STATUS_PENDING}}))
+
+    def test_is_pod_completed_succeeded(self):
+        self.assertTrue(utils.is_pod_completed({'status': {'phase':
+                        k_const.K8S_POD_STATUS_SUCCEEDED}}))
+
+    def test_is_pod_completed_failed(self):
+        self.assertTrue(utils.is_pod_completed({'status': {'phase':
+                        k_const.K8S_POD_STATUS_FAILED}}))

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -616,3 +616,12 @@ def get_subnet_by_ip(nodes_subnets, target_ip):
             return nodes_subnet
 
     return None
+
+
+def is_pod_completed(pod):
+    try:
+        return (pod['status']['phase'] in
+                (constants.K8S_POD_STATUS_SUCCEEDED,
+                 constants.K8S_POD_STATUS_FAILED))
+    except KeyError:
+        return False


### PR DESCRIPTION
When the Pod has status Completed it has finalized
its job, consequently it's expected that Kuryr will
reclycle the Neutron Ports associated with it to be
used by other Pods. However, Kuryr is considering
Completed Pods as not scheduled and the event is skipped.
This commit fixes the issue by ensuring that Completed
Pods Ports recycle is done before checking for Scheduled
Pods.

Closes-Bug: #1945680
Change-Id: I23e7901fb016d59fa76762d1f24fee47974e72df