### PR TITLE
Bug 2023731: Ensure DOWN subports are cleaned up

### DIFF
--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -663,3 +663,47 @@ def is_network_policy_enabled():
     enabled_handlers = CONF.kubernetes.enabled_handlers
     svc_sg_driver = CONF.kubernetes.service_security_groups_driver
     return 'policy' in enabled_handlers and svc_sg_driver == 'policy'
+
+
+def delete_port(leftover_port):
+    os_net = clients.get_network_client()
+
+    try:
+        # NOTE(gryf): there is unlikely, that we get an exception
+        # like PortNotFound or something, since openstacksdk
+        # doesn't raise an exception if port doesn't exists nor
+        # return any information.
+        os_net.delete_port(leftover_port.id)
+        return True
+    except os_exc.SDKException as e:
+        if "currently a subport for trunk" in str(e):
+            if leftover_port.status == "DOWN":
+                LOG.warning("Port %s is in DOWN status but still "
+                            "associated to a trunk. This should "
+                            "not happen. Trying to delete it from "
+                            "the trunk.", leftover_port.id)
+
+            # Get the trunk_id from the error message
+            trunk_id = (
+                str(e).split('trunk')[1].split('.')[0].strip())
+            try:
+                os_net.delete_trunk_subports(
+                    trunk_id, [{'port_id': leftover_port.id}])
+            except os_exc.ResourceNotFound:
+                LOG.debug(
+                    "Port %s already removed from trunk %s",
+                    leftover_port.id, trunk_id)
+            try:
+                os_net.delete_port(leftover_port.id)
+                return True
+            except os_exc.SDKException:
+                LOG.exception("Unexpected error deleting "
+                              "leftover port %s. Skipping it "
+                              "and continue with the other "
+                              "rest.", leftover_port.id)
+        else:
+            LOG.exception("Unexpected error deleting leftover "
+                          "port %s. Skipping it and "
+                          "continue with the other "
+                          "rest.", leftover_port.id)
+    return False

--- a/kuryr_kubernetes/controller/drivers/vif_pool.py
+++ b/kuryr_kubernetes/controller/drivers/vif_pool.py
@@ -549,12 +549,8 @@ class BaseVIFPool(base.VIFPoolDriver, metaclass=abc.ABCMeta):
                     del self._existing_vifs[subport.id]
                 except KeyError:
                     LOG.debug('Port %s is not in the ports list.', subport.id)
-                try:
-                    os_net.delete_port(subport.id)
-                except os_exc.SDKException:
-                    LOG.debug("Problem deleting leftover port %s. "
-                              "Skipping.", subport.id)
-                else:
+                port_deleted = c_utils.delete_port(subport)
+                if port_deleted:
                     previous_ports_to_remove.remove(subport.id)
 
             # normal ports, or subports not yet attached


### PR DESCRIPTION
Due to a known Neutron issue it's possible
to have subports with DOWN status and upon
controller restart those subports with are
not taken into account when repopulating the
pools resulting in leftovers. This commit
ensures nodes_ports_cleanup thread detach the
Port from the Trunk and remove it from the
Trunk.

Change-Id: If106637c81a5566d7bea00561f5cf1b381f97f23