### PR TITLE
Bug 2034898: Added missing raise statement for not ready resource.

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrport.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrport.py
@@ -104,6 +104,7 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
                             self.k8s.add_event(pod, 'ActivatePortFailed',
                                                'Activating Neutron port has '
                                                'timed out', 'Warning')
+                        raise
                     except os_exc.ResourceNotFound:
                         self.k8s.add_event(pod, 'ActivatePortFailed',
                                            'Activating Neutron port has '


### PR DESCRIPTION
Recently, there was Events feature added to the KuryrPort/vif handlers,
where in one case the ResourceNotReady exception needed be to handled
elsewhere, but on behalf of event handling we needed to catch it on
KuryrPort handler, but it wasn't raised causing to swallow up the
events, and slowing down ports acknowledge. This patch fixes this.

Change-Id: I203773de2b8c0d1b21ef3f722df7ed7da562a892
(cherry picked from commit 6bfe0582cf227510e6f41310fd370c35a743d932)