### PR TITLE
Bug 2035333: Limit the number of concurrent create_ports requests

### DIFF
--- a/kuryr_kubernetes/controller/drivers/base.py
+++ b/kuryr_kubernetes/controller/drivers/base.py
@@ -331,7 +331,7 @@ class PodVIFDriver(DriverBase, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     def request_vifs(self, pod, project_id, subnets, security_groups,
-                     num_ports):
+                     num_ports, semaphore):
         """Creates Neutron ports for pods and returns them as VIF objects list.
 
         It follows the same pattern as request_vif but creating the specified
@@ -351,6 +351,8 @@ class PodVIFDriver(DriverBase, metaclass=abc.ABCMeta):
                                 returned by
                                 `PodSecurityGroupsDriver.get_security_groups`
         :param num_ports: number of ports to be created
+        :param semaphore: a eventlet Semaphore to limit the number of create
+                          Port in bulk running in parallel
         :return: VIF objects list
         """
         raise NotImplementedError()

--- a/kuryr_kubernetes/controller/drivers/neutron_vif.py
+++ b/kuryr_kubernetes/controller/drivers/neutron_vif.py
@@ -58,18 +58,21 @@ class NeutronPodVIFDriver(base.PodVIFDriver):
         return ovu.neutron_to_osvif_vif(port.binding_vif_type, port, subnets)
 
     def request_vifs(self, pod, project_id, subnets, security_groups,
-                     num_ports):
+                     num_ports, semaphore):
         os_net = clients.get_network_client()
 
         rq = self._get_port_request(pod, project_id, subnets, security_groups,
                                     unbound=True)
 
         bulk_port_rq = {'ports': [rq] * num_ports}
-        try:
-            ports = list(os_net.create_ports(bulk_port_rq))
-        except os_exc.SDKException:
-            LOG.exception("Error creating bulk ports: %s", bulk_port_rq)
-            raise
+        # restrict amount of create Ports in bulk that might be running
+        # in parallel.
+        with semaphore:
+            try:
+                ports = list(os_net.create_ports(bulk_port_rq))
+            except os_exc.SDKException:
+                LOG.exception("Error creating bulk ports: %s", bulk_port_rq)
+                raise
 
         vif_plugin = ports[0].binding_vif_type
 

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_nested_vlan_vif.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_nested_vlan_vif.py
@@ -9,7 +9,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+import eventlet
 import munch
 from unittest import mock
 
@@ -106,9 +106,11 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
                                                        subports_info)
         os_net.create_ports.return_value = (p for p in [port, port])
         m_to_vif.return_value = vif
+        semaphore = mock.MagicMock(spec=eventlet.semaphore.Semaphore(20))
 
         self.assertEqual([vif, vif], cls.request_vifs(
-            m_driver, pod, project_id, subnets, security_groups, num_ports))
+            m_driver, pod, project_id, subnets, security_groups, num_ports,
+            semaphore))
 
         m_driver._get_parent_port.assert_called_once_with(pod)
         m_driver._get_trunk_id.assert_called_once_with(parent_port)
@@ -145,10 +147,11 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
         m_driver._get_trunk_id.return_value = trunk_id
         m_driver._create_subports_info.return_value = (port_request,
                                                        subports_info)
+        semaphore = mock.MagicMock(spec=eventlet.semaphore.Semaphore(20))
 
         self.assertEqual([], cls.request_vifs(m_driver, pod, project_id,
                                               subnets, security_groups,
-                                              num_ports))
+                                              num_ports, semaphore))
 
         m_driver._get_parent_port.assert_called_once_with(pod)
         m_driver._get_trunk_id.assert_called_once_with(parent_port)
@@ -185,10 +188,12 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
         m_driver._create_subports_info.return_value = (port_request,
                                                        subports_info)
         os_net.create_ports.side_effect = os_exc.SDKException
+        semaphore = mock.MagicMock(spec=eventlet.semaphore.Semaphore(20))
 
         self.assertRaises(
             os_exc.SDKException, cls.request_vifs,
-            m_driver, pod, project_id, subnets, security_groups, num_ports)
+            m_driver, pod, project_id, subnets, security_groups, num_ports,
+            semaphore)
 
         m_driver._get_parent_port.assert_called_once_with(pod)
         m_driver._get_trunk_id.assert_called_once_with(parent_port)
@@ -228,9 +233,10 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
                                                        subports_info)
         os_net.create_ports.return_value = (p for p in [port, port])
         os_net.add_trunk_subports.side_effect = os_exc.ConflictException
+        semaphore = mock.MagicMock(spec=eventlet.semaphore.Semaphore(20))
 
         self.assertEqual([], cls.request_vifs(m_driver, pod, project_id,
-                         subnets, security_groups, num_ports))
+                         subnets, security_groups, num_ports, semaphore))
 
         m_driver._get_parent_port.assert_called_once_with(pod)
         m_driver._get_trunk_id.assert_called_once_with(parent_port)
@@ -273,9 +279,10 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
                                                        subports_info)
         os_net.create_ports.return_value = (p for p in [port, port])
         os_net.add_trunk_subports.side_effect = os_exc.SDKException
+        semaphore = mock.MagicMock(spec=eventlet.semaphore.Semaphore(20))
 
         self.assertEqual([], cls.request_vifs(m_driver, pod, project_id,
-                         subnets, security_groups, num_ports))
+                         subnets, security_groups, num_ports, semaphore))
 
         m_driver._get_parent_port.assert_called_once_with(pod)
         m_driver._get_trunk_id.assert_called_once_with(parent_port)

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import eventlet
 import threading
 from unittest import mock
 import uuid
@@ -165,6 +166,11 @@ class BaseVIFPool(test_base.TestCase):
         m_driver._available_ports_pools = {}
         m_driver._last_update = {pool_key: {tuple(security_groups): 1}}
         m_driver._recovered_pools = True
+        m_driver._lock = threading.Lock()
+        m_driver._populate_pool_lock = {
+            pool_key: mock.MagicMock(spec=threading.Lock())}
+        m_driver._create_ports_semaphore = mock.MagicMock(
+            spec=eventlet.semaphore.Semaphore(20))
 
         oslo_cfg.CONF.set_override('ports_pool_min',
                                    5,


### PR DESCRIPTION
This commit proposes to limit the number of create ports
in bulk requests to 20, since Neutron takes long to handle
this requests when the Number of ports and parallel calls
increase.