### PR TITLE
Bug 2045065: Ignore Pod event if Pod is Pending with no Node set

### DIFF
--- a/kuryr_kubernetes/controller/drivers/vif_pool.py
+++ b/kuryr_kubernetes/controller/drivers/vif_pool.py
@@ -1244,7 +1244,16 @@ class MultiVIFPool(base.VIFPoolDriver):
             self._vif_drvs[pod_driver] = drv_pool
 
     def request_vif(self, pod, project_id, subnets, security_groups):
-        pod_vif_type = self._get_pod_vif_type(pod)
+        pod_info = "%s/%s" % (pod['metadata']['namespace'],
+                              pod['metadata']['name'])
+        try:
+            pod_vif_type = self._get_pod_vif_type(pod)
+        except KeyError:
+            # NOTE(maysams): No nodeName set. Event should be skipped
+            LOG.warning("Pod %s has no .spec.nodeName set. This is unexpected "
+                        "as it's supposed to be scheduled. Ignoring event.",
+                        pod_info)
+            return None
         return self._vif_drvs[pod_vif_type].request_vif(
             pod, project_id, subnets, security_groups)
 

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
@@ -141,6 +141,23 @@ class BaseVIFPool(test_base.TestCase):
                                security_groups)
         self.assertIsNone(resp)
 
+    def test_request_vif_multi_vif_pod_without_host(self):
+        cls = vif_pool.MultiVIFPool
+        m_driver = mock.MagicMock(spec=cls)
+
+        pod = get_pod_obj().copy()
+        del pod['spec']['nodeName']
+        project_id = str(uuid.uuid4())
+        subnets = mock.sentinel.subnets
+        security_groups = [mock.sentinel.security_groups]
+        m_driver._vif_drvs = {}
+        m_driver._vif_drvs['nested-vlan'] = 'NestedVIFPool'
+        m_driver._get_pod_vif_type.side_effect = KeyError
+
+        resp = cls.request_vif(m_driver, pod, project_id, subnets,
+                               security_groups)
+        self.assertIsNone(resp)
+
     @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
     @mock.patch('time.time', return_value=50)
     @ddt.data((neutron_vif.NeutronPodVIFDriver),


### PR DESCRIPTION
It's possible that a Pod had a nodeName configured and
Kuryr started handling it, but after a while it was not
scheduled in that node anymore. This impacts the processing
of the Pod event as there are steps in between that the
Pod object is retrieved again with possibly no nodeName
assigned, making the controller to constantly retry for an
event that should be ignored.

Closes-bug: 1956767
Change-Id: I123dc706e14aa3edae06a165d6c0c09e99ef28d6