### PR TITLE
CNI: Handle 404 when confirming CRD in the registry

### DIFF
--- a/kuryr_kubernetes/cni/daemon/service.py
+++ b/kuryr_kubernetes/cni/daemon/service.py
@@ -112,6 +112,10 @@ class DaemonServer(object):
             LOG.exception('Timeout on ADD request')
             error = self._error(ErrTryAgainLater, f"{e}. Try Again Later.")
             return error, httplib.GATEWAY_TIMEOUT, self.headers
+        except exceptions.CNIAPIConnectionError as e:
+            LOG.exception('Connection error on ADD request')
+            error = self._error(ErrTryAgainLater, f"{e}. Try Again Later.")
+            return error, httplib.GATEWAY_TIMEOUT, self.headers
         except pyroute2.NetlinkError as e:
             if e.code == errno.EEXIST:
                 self._check_failure()

--- a/kuryr_kubernetes/exceptions.py
+++ b/kuryr_kubernetes/exceptions.py
@@ -164,6 +164,13 @@ class CNINeutronPortActivationTimeout(CNITimeout):
             f'logs of kuryr-controller to confirm.')
 
 
+class CNIAPIConnectionError(Exception):
+    def __init__(self, name, e):
+        super().__init__(
+            f'Connection error when trying to reach Kubernetes API to get '
+            f'KuryrPort {name}: {e}')
+
+
 class CNIBindingFailure(Exception):
     """Exception indicates a binding/unbinding VIF failure in CNI"""
     def __init__(self, message):


### PR DESCRIPTION
If for some reason GET on KuryrPort to confirm that uid matches the one
in the registry returns 404, we just raised ResourceNotReady, which
basically froze cri-o for several minutes. This commit changes that to
treat such case as a uid mismatch and removes stale CRD from the
registry instead of erroring out.

Change-Id: I0bb9474c8c9806b4799574e38ecfdb465cb12897