### PR TITLE
Bug 1983056: CNI: Use K8S_POD_UID passed from CRI

### DIFF
--- a/kubernetes_crds/kuryr_crds/kuryrport.yaml
+++ b/kubernetes_crds/kuryr_crds/kuryrport.yaml
@@ -29,6 +29,8 @@ spec:
                   type: string
                 podNodeName:
                   type: string
+                podStatic:
+                  type: boolean
             status:
               type: object
               required:

--- a/kuryr_kubernetes/cni/binding/base.py
+++ b/kuryr_kubernetes/cni/binding/base.py
@@ -176,7 +176,12 @@ def disconnect(vif, instance_info, ifname, netns=None, report_health=None,
 
 @cni_utils.log_ipdb
 def cleanup(ifname, netns):
-    with get_ipdb(netns) as c_ipdb:
-        if ifname in c_ipdb.interfaces:
-            with c_ipdb.interfaces[ifname] as iface:
-                iface.remove()
+    try:
+        with get_ipdb(netns) as c_ipdb:
+            if ifname in c_ipdb.interfaces:
+                with c_ipdb.interfaces[ifname] as iface:
+                    iface.remove()
+    except Exception:
+        # Just ignore cleanup errors, there's not much we can do anyway.
+        LOG.warning('Error occured when attempting to clean up netns %s. '
+                    'Ignoring.', netns)

--- a/kuryr_kubernetes/cni/daemon/service.py
+++ b/kuryr_kubernetes/cni/daemon/service.py
@@ -152,9 +152,9 @@ class DaemonServer(object):
 
         try:
             self.plugin.delete(params)
-        except exceptions.CNIKuryrPortTimeout:
-            # NOTE(dulek): It's better to ignore this error - most of the time
-            #              it will happen when pod is long gone and CRI
+        except (exceptions.CNIKuryrPortTimeout, exceptions.CNIPodUidMismatch):
+            # NOTE(dulek): It's better to ignore these errors - most of the
+            #              time it will happen when pod is long gone and CRI
             #              overzealously tries to delete it from the network.
             #              We cannot really do anything without VIF annotation,
             #              so let's just tell CRI to move along.

--- a/kuryr_kubernetes/cni/utils.py
+++ b/kuryr_kubernetes/cni/utils.py
@@ -58,6 +58,9 @@ class CNIArgs(object):
             if not k.startswith('_'):
                 setattr(self, k, v)
 
+    def __contains__(self, key):
+        return hasattr(self, key)
+
 
 class CNIParameters(object):
     def __init__(self, env, cfg=None):

--- a/kuryr_kubernetes/constants.py
+++ b/kuryr_kubernetes/constants.py
@@ -76,6 +76,7 @@ K8S_ANNOTATION_CURRENT_DRIVER = 'current_driver'
 K8S_ANNOTATION_NEUTRON_PORT = 'neutron_id'
 
 K8S_ANNOTATION_HEADLESS_SERVICE = 'service.kubernetes.io/headless'
+K8S_ANNOTATION_CONFIG_SOURCE = 'kubernetes.io/config.source'
 
 POD_FINALIZER = KURYR_FQDN + '/pod-finalizer'
 KURYRNETWORK_FINALIZER = 'kuryrnetwork.finalizers.kuryr.openstack.org'

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -207,7 +207,8 @@ class VIFHandler(k8s_base.ResourceEventHandler):
             },
             'spec': {
                 'podUid': pod['metadata']['uid'],
-                'podNodeName': pod['spec']['nodeName']
+                'podNodeName': pod['spec']['nodeName'],
+                'podStatic': utils.is_pod_static(pod)
             },
             'status': {
                 'vifs': vifs

--- a/kuryr_kubernetes/exceptions.py
+++ b/kuryr_kubernetes/exceptions.py
@@ -170,6 +170,15 @@ class CNIBindingFailure(Exception):
         super(CNIBindingFailure, self).__init__(message)
 
 
+class CNIPodUidMismatch(CNITimeout):
+    """Excepton raised on a mismatch of CNI request's pod UID and KuryrPort"""
+    def __init__(self, name, expected, observed):
+        super().__init__(
+            f'uid {observed} of the pod {name} does not match the uid '
+            f'{expected} requested by the CNI. Dropping CNI request to prevent'
+            f' race conditions.')
+
+
 class UnreachableOctavia(Exception):
     """Exception indicates Octavia API failure and can not be reached
 

--- a/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
+++ b/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
@@ -17,6 +17,7 @@ from unittest import mock
 from oslo_config import cfg
 
 from kuryr_kubernetes.cni.plugins import k8s_cni_registry
+from kuryr_kubernetes.cni import utils
 from kuryr_kubernetes import exceptions
 from kuryr_kubernetes.tests import base
 from kuryr_kubernetes.tests import fake
@@ -33,7 +34,7 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                    'kind': 'KuryrPort',
                    'metadata': {'name': 'foo', 'uid': 'bar',
                                 'namespace': 'default'},
-                   'spec': {'podUid': 'bar'}}
+                   'spec': {'podUid': 'bar', 'podStatic': False}}
         self.vifs = fake._fake_vifs()
         registry = {'default/foo': {'kp': self.kp, 'vifs': self.vifs,
                                     'containerid': None,
@@ -41,10 +42,11 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                                     'del_received': False}}
         healthy = mock.Mock()
         self.plugin = k8s_cni_registry.K8sCNIRegistryPlugin(registry, healthy)
-        self.params = mock.Mock(args=mock.Mock(K8S_POD_NAME='foo',
-                                               K8S_POD_NAMESPACE='default'),
-                                CNI_IFNAME=self.default_iface, CNI_NETNS=123,
-                                CNI_CONTAINERID='cont_id')
+        self.params = mock.Mock(
+            args=utils.CNIArgs('K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default;'
+                               'K8S_POD_UID=bar'),
+            CNI_IFNAME=self.default_iface, CNI_NETNS=123,
+            CNI_CONTAINERID='cont_id')
 
     @mock.patch('oslo_concurrency.lockutils.lock')
     @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
@@ -62,6 +64,101 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                                   123, report_health=mock.ANY,
                                   is_default_gateway=False,
                                   container_id='cont_id')
+        self.assertEqual('cont_id',
+                         self.plugin.registry['default/foo']['containerid'])
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
+    def test_add_no_uid(self, m_connect, m_lock):
+        self.k8s_mock.get.return_value = self.kp
+
+        self.params.args = utils.CNIArgs(
+            'K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default')
+        self.plugin.add(self.params)
+
+        m_lock.assert_called_with('default/foo', external=True)
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.default_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=True,
+                                  container_id='cont_id')
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.additional_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=False,
+                                  container_id='cont_id')
+        self.k8s_mock.get.assert_any_call(
+            '/api/v1/namespaces/default/pods/foo')
+        self.assertEqual('cont_id',
+                         self.plugin.registry['default/foo']['containerid'])
+
+    @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
+    def test_add_wrong_uid(self, m_connect):
+        cfg.CONF.set_override('vif_annotation_timeout', 0, group='cni_daemon')
+        self.addCleanup(cfg.CONF.set_override, 'vif_annotation_timeout', 120,
+                        group='cni_daemon')
+        self.k8s_mock.get.return_value = self.kp
+
+        self.params.args = utils.CNIArgs(
+            'K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default;K8S_POD_UID=blob')
+        self.assertRaises(exceptions.CNIPodUidMismatch, self.plugin.add,
+                          self.params)
+
+        m_connect.assert_not_called()
+        self.k8s_mock.get.assert_not_called()
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
+    def test_add_wrong_uid_static(self, m_connect, m_lock):
+        cfg.CONF.set_override('vif_annotation_timeout', 0, group='cni_daemon')
+        self.addCleanup(cfg.CONF.set_override, 'vif_annotation_timeout', 120,
+                        group='cni_daemon')
+        self.k8s_mock.get.return_value = self.kp
+
+        self.params.args = utils.CNIArgs(
+            'K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default;K8S_POD_UID=blob')
+        self.kp['spec']['podStatic'] = True
+        self.plugin.add(self.params)
+
+        m_lock.assert_called_with('default/foo', external=True)
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.default_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=True,
+                                  container_id='cont_id')
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.additional_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=False,
+                                  container_id='cont_id')
+        self.k8s_mock.get.assert_any_call(
+            '/api/v1/namespaces/default/pods/foo')
+        self.assertEqual('cont_id',
+                         self.plugin.registry['default/foo']['containerid'])
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
+    def test_add_wrong_uid_none_static(self, m_connect, m_lock):
+        cfg.CONF.set_override('vif_annotation_timeout', 0, group='cni_daemon')
+        self.addCleanup(cfg.CONF.set_override, 'vif_annotation_timeout', 120,
+                        group='cni_daemon')
+        self.k8s_mock.get.side_effect = [
+            {'metadata': {
+                'annotations': {'kubernetes.io/config.source': 'file'}}},
+            self.kp]
+
+        self.params.args = utils.CNIArgs(
+            'K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default;K8S_POD_UID=blob')
+        del self.kp['spec']['podStatic']
+        self.plugin.add(self.params)
+
+        m_lock.assert_called_with('default/foo', external=True)
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.default_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=True,
+                                  container_id='cont_id')
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.additional_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=False,
+                                  container_id='cont_id')
+        self.k8s_mock.get.assert_any_call(
+            '/api/v1/namespaces/default/pods/foo')
         self.assertEqual('cont_id',
                          self.plugin.registry['default/foo']['containerid'])
 

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -650,6 +650,16 @@ def is_host_network(pod):
     return pod['spec'].get('hostNetwork', False)
 
 
+def is_pod_static(pod):
+    """Checks if Pod is static by comparing annotations."""
+    try:
+        annotations = pod['metadata']['annotations']
+        config_source = annotations[constants.K8S_ANNOTATION_CONFIG_SOURCE]
+        return config_source != 'api'
+    except KeyError:
+        return False
+
+
 def get_nodename():
     # NOTE(dulek): At first try to get it using environment variable,
     #              otherwise assume hostname is the nodename.


### PR DESCRIPTION
Recent versions of cri-o and containerd are passing K8S_POD_UID as a CNI
argument, alongside with K8S_POD_NAMESPACE and K8S_POD_NAME. As both
latter variables cannot be used to safely identify a pod in the API
(StatefulSet recreates pods with the same name), we were prone to race
conditions in the CNI code that we could only workaround. The end effect
was mostly IP conflict.

Now that the UID argument is passed, we're able to compare the UID from
the request with the one in the API to make sure we're wiring the
correct pod. This commit implements that by making sure to move the
check to the code actually waiting for the pod to appear in the
registry. In case of K8S_POD_UID missing from the CNI request, API call
to retrieve Pod is used as a fallback.

We also know that this check doesn't work for static pods, so CRD and
controller needed to be updated to include information if the pod is
static on the KuryrPort spec, so that we can skip the check for the
static pods without the need to fetch Pod from the API.