### PR TITLE
Parallelize ports removal.

### DIFF
--- a/kuryr_kubernetes/constants.py
+++ b/kuryr_kubernetes/constants.py
@@ -118,3 +118,5 @@ K8S_OPERATOR_EXISTS = 'exists'
 
 USERSPACE_DRIVERS = ['vfio-pci', 'uio', 'uio_pci_generic', 'igb_uio']
 MELLANOX_DRIVERS = ['mlx4_core', 'mlx5_core']
+
+LEFTOVER_RM_POOL_SIZE = 5

--- a/kuryr_kubernetes/controller/drivers/nested_vlan_vif.py
+++ b/kuryr_kubernetes/controller/drivers/nested_vlan_vif.py
@@ -105,15 +105,13 @@ class NestedVlanPodVIFDriver(nested_vif.NestedPodVIFDriver):
                 os_net.add_trunk_subports(trunk_id, subports_info)
             except os_exc.ConflictException:
                 LOG.error("vlan ids already in use on trunk")
-                for port in ports:
-                    utils.delete_port(port)
+                utils.delete_ports(ports)
                 for subport_info in subports_info:
                     self._release_vlan_id(subport_info['segmentation_id'])
                 return []
         except os_exc.SDKException:
             LOG.exception("Error happened during subport addition to trunk")
-            for port in ports:
-                utils.delete_port(port)
+            utils.delete_ports(ports)
             for subport_info in subports_info:
                 self._release_vlan_id(subport_info['segmentation_id'])
             return []

--- a/kuryr_kubernetes/controller/drivers/utils.py
+++ b/kuryr_kubernetes/controller/drivers/utils.py
@@ -16,6 +16,7 @@
 import urllib
 import uuid
 
+import eventlet
 import netaddr
 from openstack import exceptions as os_exc
 from os_vif import objects
@@ -749,3 +750,21 @@ def delete_port(leftover_port):
                           "continue with the other "
                           "rest.", leftover_port.id)
     return False
+
+
+def delete_ports(leftover_port_list):
+    pool = eventlet.GreenPool(constants.LEFTOVER_RM_POOL_SIZE)
+    return all([i for i in pool.imap(delete_port, leftover_port_list)])
+
+
+def delete_neutron_port(port):
+    os_net = clients.get_network_client()
+    try:
+        os_net.delete_port(port)
+    except Exception as ex:
+        # NOTE(gryf): Catching all the exceptions here is intentional, since
+        # this function is intended to be run in the greenthread. User needs
+        # to examine return value and decide which exception can be safely
+        # skipped, and which need to be handled/raised.
+        return ex
+    return None

--- a/kuryr_kubernetes/controller/drivers/vif_pool.py
+++ b/kuryr_kubernetes/controller/drivers/vif_pool.py
@@ -15,11 +15,11 @@
 
 import abc
 import collections
-import eventlet
 import os
 import threading
 import time
 
+import eventlet
 from kuryr.lib._i18n import _
 from kuryr.lib import constants as kl_const
 from openstack import exceptions as os_exc
@@ -488,9 +488,8 @@ class BaseVIFPool(base.VIFPoolDriver, metaclass=abc.ABCMeta):
                                       "Skipping.", port.id)
                             continue
         else:
-            for port in existing_ports:
-                if not port.binding_host_id:
-                    c_utils.delete_port(port)
+            c_utils.delete_ports([p for p in existing_ports
+                                  if not p.binding_host_id])
 
     def _cleanup_removed_nodes(self):
         """Remove ports associated to removed nodes."""
@@ -783,7 +782,8 @@ class NeutronVIFPool(BaseVIFPool):
             LOG.debug("Kuryr-controller not yet ready to delete network "
                       "pools.")
             raise exceptions.ResourceNotReady(net_id)
-        os_net = clients.get_network_client()
+
+        epool = eventlet.GreenPool(constants.LEFTOVER_RM_POOL_SIZE)
 
         # NOTE(ltomasbo): Note the pods should already be deleted, but their
         # associated ports may not have been recycled yet, therefore not being
@@ -803,7 +803,13 @@ class NeutronVIFPool(BaseVIFPool):
                     LOG.debug('Port %s is not in the ports list.', port_id)
                 # NOTE(gryf): openstack client doesn't return information, if
                 # the port deos not exists
-                os_net.delete_port(port_id)
+
+            # Delete ports concurrently
+            for result in epool.imap(c_utils.delete_neutron_port, ports_id):
+                if result:
+                    LOG.error('During Neutron port deletion an error occured: '
+                              '%s', result)
+                    raise result
 
             self._available_ports_pools[pool_key] = {}
             with self._lock:
@@ -1164,7 +1170,10 @@ class NestedVIFPool(BaseVIFPool):
             LOG.debug("Kuryr-controller not yet ready to delete network "
                       "pools.")
             raise exceptions.ResourceNotReady(net_id)
-        os_net = clients.get_network_client()
+
+        epool = eventlet.GreenPool(constants.LEFTOVER_RM_POOL_SIZE)
+        ports_to_remove = []
+
         # NOTE(ltomasbo): Note the pods should already be deleted, but their
         # associated ports may not have been recycled yet, therefore not being
         # on the available_ports_pools dict. The next call forces it to be on
@@ -1190,7 +1199,7 @@ class NestedVIFPool(BaseVIFPool):
                     del self._existing_vifs[port_id]
                 except KeyError:
                     LOG.debug('Port %s is not in the ports list.', port_id)
-                os_net.delete_port(port_id)
+                ports_to_remove.append(port_id)
 
             self._available_ports_pools[pool_key] = {}
             with self._lock:
@@ -1198,6 +1207,12 @@ class NestedVIFPool(BaseVIFPool):
                     del self._populate_pool_lock[pool_key]
                 except KeyError:
                     pass
+
+        for result in epool.imap(c_utils.delete_neutron_port, ports_to_remove):
+            if result:
+                LOG.error('During Neutron port deletion an error occured: %s',
+                          result)
+                raise result
 
 
 class MultiVIFPool(base.VIFPoolDriver):

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_nested_vlan_vif.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_nested_vlan_vif.py
@@ -197,7 +197,8 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
             trunk_id, num_ports, unbound=True)
         os_net.create_ports.assert_called_once_with(bulk_rq)
 
-    def test_request_vifs_trunk_subports_conflict(self):
+    @mock.patch('kuryr_kubernetes.controller.drivers.utils.delete_ports')
+    def test_request_vifs_trunk_subports_conflict(self, m_del_ports):
         cls = nested_vlan_vif.NestedVlanPodVIFDriver
         cls._tag_on_creation = True
         m_driver = mock.Mock(spec=cls)
@@ -240,9 +241,10 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
         os_net.create_ports.assert_called_once_with(bulk_rq)
         os_net.add_trunk_subports.assert_called_once_with(trunk_id,
                                                           subports_info)
-        os_net.delete_port.assert_called_with(port['id'])
+        m_del_ports.assert_called_once_with([port, port])
 
-    def test_request_vifs_trunk_subports_exception(self):
+    @mock.patch('kuryr_kubernetes.controller.drivers.utils.delete_ports')
+    def test_request_vifs_trunk_subports_exception(self, m_del_ports):
         cls = nested_vlan_vif.NestedVlanPodVIFDriver
         cls._tag_on_creation = False
         m_driver = mock.Mock(spec=cls)
@@ -285,7 +287,7 @@ class TestNestedVlanPodVIFDriver(test_base.TestCase):
         os_net.create_ports.assert_called_once_with(bulk_rq)
         os_net.add_trunk_subports.assert_called_once_with(trunk_id,
                                                           subports_info)
-        os_net.delete_port.assert_called_with(port['id'])
+        m_del_ports.assert_called_once_with([port, port])
 
     def test_release_vif(self):
         cls = nested_vlan_vif.NestedVlanPodVIFDriver

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
@@ -28,6 +28,7 @@ from os_vif.objects import vif as osv_vif
 from kuryr_kubernetes import constants
 from kuryr_kubernetes.controller.drivers import nested_vlan_vif
 from kuryr_kubernetes.controller.drivers import neutron_vif
+from kuryr_kubernetes.controller.drivers import utils
 from kuryr_kubernetes.controller.drivers import vif_pool
 from kuryr_kubernetes import exceptions
 from kuryr_kubernetes import os_vif_util as ovu
@@ -426,7 +427,8 @@ class BaseVIFPool(test_base.TestCase):
         os_net.networks.assert_not_called()
         os_net.delete_port.assert_not_called()
 
-    def test_cleanup_leftover_ports_no_tagging_no_binding(self):
+    @mock.patch('kuryr_kubernetes.controller.drivers.utils.delete_ports')
+    def test_cleanup_leftover_ports_no_tagging_no_binding(self, m_del_ports):
         cls = vif_pool.BaseVIFPool
         m_driver = mock.MagicMock(spec=cls)
 
@@ -439,7 +441,7 @@ class BaseVIFPool(test_base.TestCase):
 
         cls._cleanup_leftover_ports(m_driver)
         os_net.networks.assert_not_called()
-        os_net.delete_port.assert_called_once_with(port.id)
+        m_del_ports.assert_called_once_with([port])
 
 
 @ddt.ddt
@@ -888,11 +890,12 @@ class NeutronVIFPool(test_base.TestCase):
         m_get_subnet.assert_not_called()
         m_to_osvif.assert_not_called()
 
-    def test_delete_network_pools(self):
+    @mock.patch('eventlet.GreenPool')
+    def test_delete_network_pools(self, m_green_pool):
         cls = vif_pool.NeutronVIFPool
         m_driver = mock.MagicMock(spec=cls)
-
-        os_net = self.useFixture(k_fix.MockNetworkClient()).client
+        m_pool = mock.MagicMock()
+        m_green_pool.return_value = m_pool
 
         net_id = mock.sentinel.net_id
         pool_key = ('node_ip', 'project_id')
@@ -911,7 +914,8 @@ class NeutronVIFPool(test_base.TestCase):
 
         m_driver._trigger_return_to_pool.assert_called_once()
         m_driver._get_pool_key_net.assert_called_once()
-        os_net.delete_port.assert_called_once_with(port_id)
+        m_pool.imap.assert_called_once_with(utils.delete_neutron_port,
+                                            [port_id])
 
     def test_delete_network_pools_not_ready(self):
         cls = vif_pool.NeutronVIFPool
@@ -928,11 +932,12 @@ class NeutronVIFPool(test_base.TestCase):
         m_driver._get_pool_key_net.assert_not_called()
         os_net.delete_port.assert_not_called()
 
-    def test_delete_network_pools_missing_port_id(self):
+    @mock.patch('eventlet.GreenPool')
+    def test_delete_network_pools_missing_port_id(self, m_green_pool):
         cls = vif_pool.NeutronVIFPool
         m_driver = mock.MagicMock(spec=cls)
-
-        os_net = self.useFixture(k_fix.MockNetworkClient()).client
+        m_pool = mock.MagicMock()
+        m_green_pool.return_value = m_pool
 
         net_id = mock.sentinel.net_id
         pool_key = ('node_ip', 'project_id')
@@ -951,7 +956,8 @@ class NeutronVIFPool(test_base.TestCase):
 
         m_driver._trigger_return_to_pool.assert_called_once()
         m_driver._get_pool_key_net.assert_called_once()
-        os_net.delete_port.assert_called_once_with(port_id)
+        m_pool.imap.assert_called_once_with(utils.delete_neutron_port,
+                                            [port_id])
 
 
 @ddt.ddt
@@ -1792,14 +1798,15 @@ class NestedVIFPool(test_base.TestCase):
         self.assertEqual(m_driver._available_ports_pools, {})
         os_net.delete_port.assert_not_called()
 
-    def test_delete_network_pools(self):
+    @mock.patch('eventlet.GreenPool')
+    def test_delete_network_pools(self, m_green_pool):
         cls = vif_pool.NestedVIFPool
         m_driver = mock.MagicMock(spec=cls)
         cls_vif_driver = nested_vlan_vif.NestedVlanPodVIFDriver
         vif_driver = mock.MagicMock(spec=cls_vif_driver)
         m_driver._drv_vif = vif_driver
-
-        os_net = self.useFixture(k_fix.MockNetworkClient()).client
+        m_pool = mock.MagicMock()
+        m_green_pool.return_value = m_pool
 
         net_id = mock.sentinel.net_id
         pool_key = ('node_ip', 'project_id')
@@ -1827,7 +1834,8 @@ class NestedVIFPool(test_base.TestCase):
         m_driver._drv_vif._remove_subports.assert_called_once_with(trunk_id,
                                                                    [port_id])
         m_driver._drv_vif._release_vlan_id.assert_called_once_with(vlan_id)
-        os_net.delete_port.assert_called_once_with(port_id)
+        m_pool.imap.assert_called_once_with(utils.delete_neutron_port,
+                                            [port_id])
 
     def test_delete_network_pools_not_ready(self):
         cls = vif_pool.NestedVIFPool
@@ -1884,14 +1892,15 @@ class NestedVIFPool(test_base.TestCase):
         m_driver._drv_vif._release_vlan_id.assert_not_called()
         os_net.delete_port.assert_not_called()
 
-    def test_delete_network_pools_missing_port(self):
+    @mock.patch('eventlet.GreenPool')
+    def test_delete_network_pools_missing_port(self, m_green_pool):
         cls = vif_pool.NestedVIFPool
         m_driver = mock.MagicMock(spec=cls)
         cls_vif_driver = nested_vlan_vif.NestedVlanPodVIFDriver
         vif_driver = mock.MagicMock(spec=cls_vif_driver)
         m_driver._drv_vif = vif_driver
-
-        os_net = self.useFixture(k_fix.MockNetworkClient()).client
+        m_pool = mock.MagicMock()
+        m_green_pool.return_value = m_pool
 
         net_id = mock.sentinel.net_id
         pool_key = ('node_ip', 'project_id')
@@ -1919,4 +1928,5 @@ class NestedVIFPool(test_base.TestCase):
         m_driver._drv_vif._remove_subports.assert_called_once_with(trunk_id,
                                                                    [port_id])
         m_driver._drv_vif._release_vlan_id.assert_not_called()
-        os_net.delete_port.assert_called_once_with(port_id)
+        m_pool.imap.assert_called_once_with(utils.delete_neutron_port,
+                                            [port_id])


### PR DESCRIPTION
During removal of Neutron resources, sometimes there could be hanging
orphaned ports. Till now, all the removal was done one by one which
slows down removing process. In this change there is introduced removing
port in parallel in five concurrently run workers.

Change-Id: I74842989784601325b6d8977da4bc936ceedbc0e
(cherry picked from commit e9fd3bb13463f4a11f76694222dfc4f727c658b9)