### PR TITLE
Bug 1997120: CNI: Watch for deleted pods 

### DIFF
--- a/kuryr_kubernetes/cni/daemon/service.py
+++ b/kuryr_kubernetes/cni/daemon/service.py
@@ -21,7 +21,6 @@ import queue
 import sys
 import threading
 import time
-import urllib.parse
 import urllib3
 
 import cotyledon
@@ -31,27 +30,23 @@ from pyroute2.ipdb import transactional
 from werkzeug import serving
 
 import os_vif
-from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
 
 from kuryr_kubernetes import clients
-from kuryr_kubernetes.cni import handlers as h_cni
+from kuryr_kubernetes.cni.daemon import watcher_service
 from kuryr_kubernetes.cni import health
 from kuryr_kubernetes.cni.plugins import k8s_cni_registry
 from kuryr_kubernetes.cni import prometheus_exporter
 from kuryr_kubernetes.cni import utils as cni_utils
 from kuryr_kubernetes import config
-from kuryr_kubernetes import constants as k_const
 from kuryr_kubernetes import exceptions
 from kuryr_kubernetes import objects
-from kuryr_kubernetes import utils
-from kuryr_kubernetes import watcher as k_watcher
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
-HEALTH_CHECKER_DELAY = 5
+ErrContainerUnknown = 3
 ErrInvalidEnvironmentVariables = 4
 ErrTryAgainLater = 11
 ErrInternal = 999
@@ -107,6 +102,10 @@ class DaemonServer(object):
         try:
             vif = self.plugin.add(params)
             data = jsonutils.dumps(vif.obj_to_primitive())
+        except (exceptions.CNIPodGone, exceptions.CNIPodUidMismatch) as e:
+            LOG.warning('Pod deleted while processing ADD request')
+            error = self._error(ErrContainerUnknown, str(e))
+            return error, httplib.GONE, self.headers
         except exceptions.CNITimeout as e:
             LOG.exception('Timeout on ADD request')
             error = self._error(ErrTryAgainLater, f"{e}. Try Again Later.")
@@ -246,89 +245,6 @@ class CNIDaemonServerService(cotyledon.Service):
         self.server.stop()
 
 
-class CNIDaemonWatcherService(cotyledon.Service):
-    name = "watcher"
-
-    def __init__(self, worker_id, registry, healthy):
-        super(CNIDaemonWatcherService, self).__init__(worker_id)
-        self.pipeline = None
-        self.watcher = None
-        self.health_thread = None
-        self.registry = registry
-        self.healthy = healthy
-
-    def run(self):
-        self.pipeline = h_cni.CNIPipeline()
-        self.pipeline.register(h_cni.CallbackHandler(self.on_done,
-                                                     self.on_deleted))
-        self.watcher = k_watcher.Watcher(self.pipeline)
-        query_label = urllib.parse.quote_plus(f'{k_const.KURYRPORT_LABEL}='
-                                              f'{utils.get_nodename()}')
-
-        self.watcher.add(f'{k_const.K8S_API_CRD_KURYRPORTS}'
-                         f'?labelSelector={query_label}')
-
-        self.is_running = True
-        self.health_thread = threading.Thread(
-            target=self._start_watcher_health_checker)
-        self.health_thread.start()
-        self.watcher.start()
-
-    def _start_watcher_health_checker(self):
-        while self.is_running:
-            if not self.watcher.is_alive():
-                LOG.debug("Reporting watcher not healthy.")
-                with self.healthy.get_lock():
-                    self.healthy.value = False
-            time.sleep(HEALTH_CHECKER_DELAY)
-
-    def on_done(self, kuryrport, vifs):
-        kp_name = utils.get_res_unique_name(kuryrport)
-        with lockutils.lock(kp_name, external=True):
-            if (kp_name not in self.registry or
-                    self.registry[kp_name]['kp']['metadata']['uid']
-                    != kuryrport['metadata']['uid']):
-                self.registry[kp_name] = {'kp': kuryrport,
-                                          'vifs': vifs,
-                                          'containerid': None,
-                                          'vif_unplugged': False,
-                                          'del_received': False}
-            else:
-                old_vifs = self.registry[kp_name]['vifs']
-                for iface in vifs:
-                    if old_vifs[iface].active != vifs[iface].active:
-                        kp_dict = self.registry[kp_name]
-                        kp_dict['vifs'] = vifs
-                        self.registry[kp_name] = kp_dict
-
-    def on_deleted(self, kp):
-        kp_name = utils.get_res_unique_name(kp)
-        try:
-            if kp_name in self.registry:
-                # NOTE(ndesh): We need to lock here to avoid race condition
-                #              with the deletion code for CNI DEL so that
-                #              we delete the registry entry exactly once
-                with lockutils.lock(kp_name, external=True):
-                    if self.registry[kp_name]['vif_unplugged']:
-                        del self.registry[kp_name]
-                    else:
-                        kp_dict = self.registry[kp_name]
-                        kp_dict['del_received'] = True
-                        self.registry[kp_name] = kp_dict
-        except KeyError:
-            # This means someone else removed it. It's odd but safe to ignore.
-            LOG.debug('KuryrPort %s entry already removed from registry while '
-                      'handling DELETED event. Ignoring.', kp_name)
-            pass
-
-    def terminate(self):
-        self.is_running = False
-        if self.health_thread:
-            self.health_thread.join()
-        if self.watcher:
-            self.watcher.stop()
-
-
 class CNIDaemonHealthServerService(cotyledon.Service):
     name = "health"
 
@@ -392,7 +308,10 @@ class CNIDaemonServiceManager(cotyledon.ServiceManager):
         registry = self.manager.dict()  # For Watcher->Server communication.
         healthy = multiprocessing.Value(c_bool, True)
         metrics = self.manager.Queue()
-        self.add(CNIDaemonWatcherService, workers=1, args=(registry, healthy,))
+        self.add(watcher_service.KuryrPortWatcherService, workers=1,
+                 args=(registry, healthy,))
+        self.add(watcher_service.PodWatcherService, workers=1,
+                 args=(registry, healthy,))
         self._server_service = self.add(CNIDaemonServerService, workers=1,
                                         args=(registry, healthy, metrics,))
         self.add(CNIDaemonHealthServerService, workers=1, args=(healthy,))

--- a/kuryr_kubernetes/cni/daemon/watcher_service.py
+++ b/kuryr_kubernetes/cni/daemon/watcher_service.py
@@ -1,0 +1,94 @@
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+import urllib.parse
+
+import cotyledon
+from oslo_config import cfg
+from oslo_log import log as logging
+
+from kuryr_kubernetes.cni import handlers
+from kuryr_kubernetes import constants as k_const
+from kuryr_kubernetes import utils
+from kuryr_kubernetes import watcher as k_watcher
+
+
+HEALTH_CHECKER_DELAY = 5
+LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
+
+
+class BaseCNIDaemonWatcherService(cotyledon.Service):
+    name = "watcher"
+
+    def __init__(self, worker_id, handler, path, registry, healthy):
+        super().__init__(worker_id)
+        self.pipeline = None
+        self.watcher = None
+        self.health_thread = None
+        self.handler = handler
+        self.registry = registry
+        self.healthy = healthy
+        self.path = path
+        self.is_running = False
+
+    def run(self):
+        self.pipeline = handlers.CNIPipeline()
+        self.pipeline.register(self.handler)
+        self.watcher = k_watcher.Watcher(self.pipeline)
+        self.watcher.add(self.path)
+
+        self.is_running = True
+
+        self.health_thread = threading.Thread(
+            target=self._start_watcher_health_checker)
+        self.health_thread.start()
+
+        self.watcher.start()
+
+    def _start_watcher_health_checker(self):
+        while self.is_running:
+            if not self.watcher.is_alive():
+                LOG.warning(f"Reporting watcher {self.__class__.__name__} is "
+                            f"not healthy because it's not running anymore.")
+                with self.healthy.get_lock():
+                    self.healthy.value = False
+            time.sleep(HEALTH_CHECKER_DELAY)
+
+    def terminate(self):
+        self.is_running = False
+        if self.health_thread:
+            self.health_thread.join()
+        if self.watcher:
+            self.watcher.stop()
+
+
+class KuryrPortWatcherService(BaseCNIDaemonWatcherService):
+    def __init__(self, worker_id, registry, healthy):
+        query_label = urllib.parse.quote_plus(f'{k_const.KURYRPORT_LABEL}='
+                                              f'{utils.get_nodename()}')
+        path = f'{k_const.K8S_API_CRD_KURYRPORTS}?labelSelector={query_label}'
+        handler = handlers.CNIKuryrPortHandler(registry)
+        super().__init__(worker_id, handler, path, registry, healthy)
+
+
+class PodWatcherService(BaseCNIDaemonWatcherService):
+    def __init__(self, worker_id, registry, healthy):
+        query_label = urllib.parse.quote_plus(f'spec.nodeName='
+                                              f'{utils.get_nodename()}')
+        path = f'{k_const.K8S_API_PODS}?fieldSelector={query_label}'
+        handler = handlers.CNIPodHandler(registry)
+        super().__init__(worker_id, handler, path, registry, healthy)

--- a/kuryr_kubernetes/constants.py
+++ b/kuryr_kubernetes/constants.py
@@ -16,6 +16,7 @@
 KURYR_FQDN = 'kuryr.openstack.org'
 
 K8S_API_BASE = '/api/v1'
+K8S_API_PODS = K8S_API_BASE + '/pods'
 K8S_API_NAMESPACES = K8S_API_BASE + '/namespaces'
 K8S_API_CRD_VERSION = 'openstack.org/v1'
 K8S_API_CRD = '/apis/' + K8S_API_CRD_VERSION
@@ -91,6 +92,7 @@ K8S_OS_VIF_NOOP_PLUGIN = "noop"
 
 CNI_EXCEPTION_CODE = 100
 CNI_TIMEOUT_CODE = 200
+CNI_DELETED_POD_SENTINEL = None
 
 KURYR_PORT_NAME = 'kuryr-pool-port'
 KURYR_VIF_TYPE_SRIOV = 'sriov'

--- a/kuryr_kubernetes/exceptions.py
+++ b/kuryr_kubernetes/exceptions.py
@@ -170,13 +170,20 @@ class CNIBindingFailure(Exception):
         super(CNIBindingFailure, self).__init__(message)
 
 
-class CNIPodUidMismatch(CNITimeout):
+class CNIPodUidMismatch(Exception):
     """Excepton raised on a mismatch of CNI request's pod UID and KuryrPort"""
     def __init__(self, name, expected, observed):
         super().__init__(
             f'uid {observed} of the pod {name} does not match the uid '
             f'{expected} requested by the CNI. Dropping CNI request to prevent'
             f' race conditions.')
+
+
+class CNIPodGone(Exception):
+    """Excepton raised when Pod got deleted while processing a CNI request"""
+    def __init__(self, name):
+        super().__init__(
+            f'Pod {name} got deleted while processing the CNI ADD request.')
 
 
 class UnreachableOctavia(Exception):

--- a/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
+++ b/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
@@ -197,8 +197,9 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                                      is_default_gateway=False,
                                      container_id='cont_id')
 
+    @mock.patch('oslo_concurrency.lockutils.lock')
     @mock.patch('kuryr_kubernetes.cni.binding.base.disconnect')
-    def test_del_wrong_container_id(self, m_disconnect):
+    def test_del_wrong_container_id(self, m_disconnect, m_lock):
         registry = {'default/foo': {'kp': self.kp, 'vifs': self.vifs,
                                     'containerid': 'different'}}
         healthy = mock.Mock()
@@ -206,6 +207,7 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
         self.plugin.delete(self.params)
 
         m_disconnect.assert_not_called()
+        m_lock.assert_called_with('default/foo', external=True)
 
     @mock.patch('oslo_concurrency.lockutils.lock')
     @mock.patch('time.sleep', mock.Mock())

--- a/kuryr_kubernetes/tests/unit/cni/test_handlers.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_handlers.py
@@ -1,0 +1,68 @@
+# Copyright 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from kuryr_kubernetes.cni import handlers
+from kuryr_kubernetes.tests import base
+
+
+class TestCNIDaemonHandlers(base.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.registry = {}
+        self.pod = {'metadata': {'namespace': 'testing',
+                                 'name': 'default'},
+                    'vif_unplugged': False,
+                    'del_receieved': False}
+        self.healthy = mock.Mock()
+        self.port_handler = handlers.CNIKuryrPortHandler(self.registry)
+        self.pod_handler = handlers.CNIPodHandler(self.registry)
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_kp_on_deleted(self, m_lock):
+        pod = self.pod
+        pod['vif_unplugged'] = True
+        pod_name = 'testing/default'
+        self.registry[pod_name] = pod
+        self.port_handler.on_deleted(pod)
+        self.assertNotIn(pod_name, self.registry)
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_kp_on_deleted_false(self, m_lock):
+        pod = self.pod
+        pod_name = 'testing/default'
+        self.registry[pod_name] = pod
+        self.port_handler.on_deleted(pod)
+        self.assertIn(pod_name, self.registry)
+        self.assertIs(True, pod['del_received'])
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_pod_on_finalize(self, m_lock):
+        pod = self.pod
+        pod_name = 'testing/default'
+        self.pod_handler.on_finalize(pod)
+        self.assertIn(pod_name, self.registry)
+        self.assertIsNone(self.registry[pod_name])
+        m_lock.assert_called_once_with(pod_name, external=True)
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_pod_on_finalize_exists(self, m_lock):
+        pod = self.pod
+        pod_name = 'testing/default'
+        self.registry[pod_name] = pod
+        self.pod_handler.on_finalize(pod)
+        self.assertIn(pod_name, self.registry)
+        self.assertIsNotNone(self.registry[pod_name])
+        m_lock.assert_called_once_with(pod_name, external=True)

--- a/kuryr_kubernetes/tests/unit/cni/test_service.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_service.py
@@ -107,34 +107,3 @@ class TestDaemonServer(base.TestCase):
 
         m_delete.assert_called_once_with(mock.ANY)
         self.assertEqual(500, resp.status_code)
-
-
-class TestCNIDaemonWatcherService(base.TestCase):
-    def setUp(self):
-        super(TestCNIDaemonWatcherService, self).setUp()
-        self.registry = {}
-        self.pod = {'metadata': {'namespace': 'testing',
-                                 'name': 'default'},
-                    'vif_unplugged': False,
-                    'del_receieved': False}
-        self.healthy = mock.Mock()
-        self.watcher = service.CNIDaemonWatcherService(
-            0, self.registry, self.healthy)
-
-    @mock.patch('oslo_concurrency.lockutils.lock')
-    def test_on_deleted(self, m_lock):
-        pod = self.pod
-        pod['vif_unplugged'] = True
-        pod_name = 'testing/default'
-        self.registry[pod_name] = pod
-        self.watcher.on_deleted(pod)
-        self.assertNotIn(pod_name, self.registry)
-
-    @mock.patch('oslo_concurrency.lockutils.lock')
-    def test_on_deleted_false(self, m_lock):
-        pod = self.pod
-        pod_name = 'testing/default'
-        self.registry[pod_name] = pod
-        self.watcher.on_deleted(pod)
-        self.assertIn(pod_name, self.registry)
-        self.assertIs(True, pod['del_received'])


### PR DESCRIPTION
It can happen that we get the CNI request, but pod gets deleted before
kuryr-controller was able to create KuryrPort for it. If kuryr-daemon
only watches for KuryrPort events it will not be able to notice that
and will wait until the timeout, which in effect doesn't play well with
some K8s tests.

This commit adds a separate Service that will watch on Pod events and if
Pod gets deleted we'll make sure to put a sentinel value (None) into the
registry so that the thread waiting for the KuryrPort to appear there
will know that it has to stop and raise an error.