### PR TITLE
Bug 2094801: Strip leading zeros from "funny" Service IPs

### DIFF
--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import netaddr
+
 from kuryr.lib._i18n import _
 from oslo_log import log as logging
 
@@ -105,7 +107,7 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
 
     def _get_service_ip(self, service):
         if self._is_supported_type(service):
-            return service['spec'].get('clusterIP')
+            return self._strip_funny_ip(service['spec'].get('clusterIP'))
         return None
 
     def _should_ignore(self, service):
@@ -257,7 +259,7 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
             spec['provider'] = self._lb_provider
 
         if spec_lb_ip is not None:
-            spec['lb_ip'] = spec_lb_ip
+            spec['lb_ip'] = self._strip_funny_ip(spec_lb_ip)
         timeout_cli, timeout_mem = self._get_data_timeout_annotation(service)
         spec['timeout_client_data'] = timeout_cli
         spec['timeout_member_data'] = timeout_mem
@@ -306,6 +308,9 @@ class ServiceHandler(k8s_base.ResourceEventHandler):
                 return True
 
         return False
+
+    def _strip_funny_ip(self, ip):
+        return str(netaddr.IPAddress(ip, flags=netaddr.core.ZEROFILL))
 
 
 class EndpointsHandler(k8s_base.ResourceEventHandler):


### PR DESCRIPTION
According to [1] we're supposed to support "funny" Service IPs, which
means IPs with leading zeros. Unlike unix in general we should not parse
them as octal values, but rather treat them like without leading zeros.
This commit makes sure that we strip the zeros from both ClusterIP and
LoadBalancerIP before we put them into KuryrLoadBalancer struct. This
means that later on Octavia and Neutron will get values that they
support and will proceed with LB or FIP creation normally.

[1] https://github.com/kubernetes/kubernetes/blob/v1.24.1/test/e2e/network/funny_ips.go