### PR TITLE
Bug 2097246: Use upper-constraints.txt from stable/xena in UT

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ passenv = HOME
 setenv = VIRTUAL_ENV={envdir}
 usedevelop = True
 install_command = pip install {opts} {packages}
-deps = -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+deps = -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/xena}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 allowlist_externals = sh


### PR DESCRIPTION
Current OpenStack release - Zed, drops support for Python 3.6. As we
still run 3.6 here, this commit makes sure to use stable/xena
upper-constraints.txt file when running unit tests to make sure
dependencies support Python 3.6.