### PR TITLE
Bug OCPBUGS-577: Fix unbound router_id variable while creating event

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrnetwork.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrnetwork.py
@@ -97,7 +97,7 @@ class KuryrNetworkHandler(k8s_base.ResourceEventHandler):
             except os_exc.SDKException as ex:
                 self.k8s.add_event(kuryrnet_crd, 'AddingSubnetToRouterFailed',
                                    f'Error adding Neutron subnet {subnet_id} '
-                                   f'to router {router_id}: {ex.details}',
+                                   f'to router: {ex.details}',
                                    'Warning')
                 raise
             status = {'routerId': router_id, 'populated': False}


### PR DESCRIPTION
If there was any SDK exception while adding Subnet to the Router
e.g. 504 Gateway Time-out, no router_id would be returned causing
the Kuryr controller to restart when trying to create an event with
the unbound variable router_id. This commit fixes the issue by
removing the variable.

Change-Id: Ib26fce6ccdc83c61821b54297a388d0acd2da2c7