### PR TITLE
Bug OCPBUGS-198: Cleanup KuryrPort when Pod is missing

### DIFF
--- a/kuryr_kubernetes/controller/drivers/base.py
+++ b/kuryr_kubernetes/controller/drivers/base.py
@@ -358,7 +358,7 @@ class PodVIFDriver(DriverBase, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def release_vif(self, pod, vif, project_id=None, security_groups=None):
+    def release_vif(self, pod, vif, project_id=None):
         """Unlinks Neutron port corresponding to VIF object from pod.
 
         Implementing drivers must ensure the port is either deleted or made
@@ -367,13 +367,10 @@ class PodVIFDriver(DriverBase, metaclass=abc.ABCMeta):
         :param pod: dict containing Kubernetes Pod object
         :param vif: VIF object as returned by `PodVIFDriver.request_vif`
         :param project_id: OpenStack project ID
-        :param security_groups: list containing security groups'
-                                IDs as returned by
-                                `PodSecurityGroupsDriver.get_security_groups`
         """
         raise NotImplementedError()
 
-    def release_vifs(self, pods, vifs, project_id=None, security_groups=None):
+    def release_vifs(self, pods, vifs, project_id=None):
         """Unlinks Neutron ports corresponding to VIF objects.
 
          It follows the same pattern as release_vif but releasing num_ports
@@ -383,9 +380,6 @@ class PodVIFDriver(DriverBase, metaclass=abc.ABCMeta):
         :param vifs: list of VIF objects as returned by
                      `PodVIFDriver.request_vif`
         :param project_id: (optional) OpenStack project ID
-        :param security_groups: (optional) list containing security groups'
-                                IDs as returned by
-                                `PodSecurityGroupsDriver.get_security_groups`
         """
         raise NotImplementedError()
 

--- a/kuryr_kubernetes/controller/drivers/nested_dpdk_vif.py
+++ b/kuryr_kubernetes/controller/drivers/nested_dpdk_vif.py
@@ -51,7 +51,7 @@ class NestedDpdkPodVIFDriver(nested_vif.NestedPodVIFDriver):
         # TODO(garyloug): provide an implementation
         raise NotImplementedError()
 
-    def release_vif(self, pod, vif, project_id=None, security_groups=None):
+    def release_vif(self, pod, vif, project_id=None):
         compute = clients.get_compute_client()
 
         vm_id = self._get_parent_port(pod).device_id

--- a/kuryr_kubernetes/controller/drivers/nested_macvlan_vif.py
+++ b/kuryr_kubernetes/controller/drivers/nested_macvlan_vif.py
@@ -65,7 +65,7 @@ class NestedMacvlanPodVIFDriver(nested_vif.NestedPodVIFDriver):
         # TODO(mchiappe): provide an implementation
         raise NotImplementedError()
 
-    def release_vif(self, pod, vif, project_id=None, security_groups=None):
+    def release_vif(self, pod, vif, project_id=None):
         os_net = clients.get_network_client()
 
         attempts = kuryr_config.CONF.pod_vif_nested.rev_update_attempts

--- a/kuryr_kubernetes/controller/drivers/nested_vlan_vif.py
+++ b/kuryr_kubernetes/controller/drivers/nested_vlan_vif.py
@@ -157,7 +157,7 @@ class NestedVlanPodVIFDriver(nested_vif.NestedPodVIFDriver):
                             "rechecked when event will be retried.", vif.id)
             raise
 
-    def release_vif(self, pod, vif, project_id=None, security_groups=None):
+    def release_vif(self, pod, vif, project_id=None):
         os_net = clients.get_network_client()
         parent_port = self._get_parent_port(pod)
         trunk_id = self._get_trunk_id(parent_port)

--- a/kuryr_kubernetes/controller/drivers/neutron_vif.py
+++ b/kuryr_kubernetes/controller/drivers/neutron_vif.py
@@ -93,7 +93,7 @@ class NeutronPodVIFDriver(base.PodVIFDriver):
             vifs.append(vif)
         return vifs
 
-    def release_vif(self, pod, vif, project_id=None, security_groups=None):
+    def release_vif(self, pod, vif, project_id=None):
         clients.get_network_client().delete_port(vif.id)
 
     def activate_vif(self, vif, **kwargs):

--- a/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
+++ b/kuryr_kubernetes/tests/unit/controller/drivers/test_vif_pool.py
@@ -1322,21 +1322,6 @@ class NestedVIFPool(test_base.TestCase):
                                                                   port_id)
         os_net.delete_port.assert_not_called()
 
-    def test__get_parent_port_ip(self):
-        cls = vif_pool.NestedVIFPool
-        m_driver = mock.MagicMock(spec=cls)
-
-        os_net = self.useFixture(k_fix.MockNetworkClient()).client
-
-        port_id = str(uuid.uuid4())
-        ip_address = mock.sentinel.ip_address
-
-        port_obj = fake.get_port_obj(ip_address=ip_address)
-        os_net.get_port.return_value = port_obj
-
-        self.assertEqual(ip_address, cls._get_parent_port_ip(m_driver,
-                                                             port_id))
-
     @mock.patch('kuryr_kubernetes.utils.get_subnet')
     def test__get_trunk_info(self, m_get_subnet):
         cls = vif_pool.NestedVIFPool

--- a/kuryr_kubernetes/tests/unit/test_utils.py
+++ b/kuryr_kubernetes/tests/unit/test_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from unittest import mock
+import uuid
 
 import munch
 from openstack import exceptions as os_exc
@@ -23,6 +24,7 @@ from kuryr_kubernetes import constants as k_const
 from kuryr_kubernetes import exceptions as k_exc
 from kuryr_kubernetes.objects import vif
 from kuryr_kubernetes.tests import base as test_base
+from kuryr_kubernetes.tests import fake
 from kuryr_kubernetes.tests.unit import kuryr_fixtures as k_fix
 from kuryr_kubernetes import utils
 
@@ -554,3 +556,14 @@ class TestUtils(test_base.TestCase):
 
         m_get_net.assert_called_once()
         m_net.delete_port.assert_not_called()
+
+    def test__get_parent_port_ip(self):
+        os_net = self.useFixture(k_fix.MockNetworkClient()).client
+
+        port_id = str(uuid.uuid4())
+        ip_address = mock.sentinel.ip_address
+
+        port_obj = fake.get_port_obj(ip_address=ip_address)
+        os_net.get_port.return_value = port_obj
+
+        self.assertEqual(ip_address, utils.get_parent_port_ip(port_id))

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -806,3 +806,26 @@ def cleanup_dead_networks():
             except os_exc.SDKException as ex:
                 LOG.warning('There was an issue with network "%s" '
                             'removal: %s', net, ex)
+
+
+def get_parent_port_id(vif_obj):
+    os_net = clients.get_network_client()
+    tags = []
+
+    if CONF.neutron_defaults.resource_tags:
+        tags = CONF.neutron_defaults.resource_tags
+
+    trunks = os_net.trunks(tags=tags)
+
+    for trunk in trunks:
+        for sp in trunk.sub_ports:
+            if sp['port_id'] == vif_obj.id:
+                return trunk.port_id
+
+    return None
+
+
+def get_parent_port_ip(port_id):
+    os_net = clients.get_network_client()
+    parent_port = os_net.get_port(port_id)
+    return parent_port.fixed_ips[0]['ip_address']


### PR DESCRIPTION
We can easily imagine an user frustrated by his pod not getting deleted
and opting to remove the finalizer from the Pod. If the cause of the
deletion delay was the kuryr-controller being down, we end up with an
orphaned KuryrPort. At the moment this causes crashes, which obviously
it shouldn't. Moreover we should figure out how to clean up the Neutron
port if that happens. This commit does so as explained below.

1. KuryrPort on_present() will trigger its deletion when it detects that
   Pod does not longer exist.
2. Turns out security_groups parameter passed to release_vif() was never
   used. I removed it from drivers and got rid of get_security_groups()
   call from on_finalize() as it's no longer necessary.
3. When we cannot get the Pod in KuryrPort on_finalize() we attempt to
   gather info required to cleanup the KuryrPort and "mock" a Pod
   object. A precaution is added that any error from release_vif() is
   ignored in that case to make sure failed cleanup is not causing the
   system to go down.