### PR TITLE
OCPBUGS-11828: CNI: Watch for deleted pods 

### DIFF
--- a/kubernetes_crds/kuryr_crds/kuryrport.yaml
+++ b/kubernetes_crds/kuryr_crds/kuryrport.yaml
@@ -29,6 +29,8 @@ spec:
                   type: string
                 podNodeName:
                   type: string
+                podStatic:
+                  type: boolean
             status:
               type: object
               required:

--- a/kuryr_kubernetes/cni/binding/base.py
+++ b/kuryr_kubernetes/cni/binding/base.py
@@ -176,7 +176,12 @@ def disconnect(vif, instance_info, ifname, netns=None, report_health=None,
 
 @cni_utils.log_ipdb
 def cleanup(ifname, netns):
-    with get_ipdb(netns) as c_ipdb:
-        if ifname in c_ipdb.interfaces:
-            with c_ipdb.interfaces[ifname] as iface:
-                iface.remove()
+    try:
+        with get_ipdb(netns) as c_ipdb:
+            if ifname in c_ipdb.interfaces:
+                with c_ipdb.interfaces[ifname] as iface:
+                    iface.remove()
+    except Exception:
+        # Just ignore cleanup errors, there's not much we can do anyway.
+        LOG.warning('Error occured when attempting to clean up netns %s. '
+                    'Ignoring.', netns)

--- a/kuryr_kubernetes/cni/daemon/service.py
+++ b/kuryr_kubernetes/cni/daemon/service.py
@@ -18,11 +18,9 @@ from http import client as httplib
 import multiprocessing
 import os
 import queue
-import socket
 import sys
 import threading
 import time
-import urllib.parse
 import urllib3
 
 import cotyledon
@@ -32,27 +30,23 @@ from pyroute2.ipdb import transactional
 from werkzeug import serving
 
 import os_vif
-from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
 
 from kuryr_kubernetes import clients
-from kuryr_kubernetes.cni import handlers as h_cni
+from kuryr_kubernetes.cni.daemon import watcher_service
 from kuryr_kubernetes.cni import health
 from kuryr_kubernetes.cni.plugins import k8s_cni_registry
 from kuryr_kubernetes.cni import prometheus_exporter
 from kuryr_kubernetes.cni import utils as cni_utils
 from kuryr_kubernetes import config
-from kuryr_kubernetes import constants as k_const
 from kuryr_kubernetes import exceptions
 from kuryr_kubernetes import objects
-from kuryr_kubernetes import utils
-from kuryr_kubernetes import watcher as k_watcher
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
-HEALTH_CHECKER_DELAY = 5
+ErrContainerUnknown = 3
 ErrInvalidEnvironmentVariables = 4
 ErrTryAgainLater = 11
 ErrInternal = 999
@@ -108,6 +102,10 @@ class DaemonServer(object):
         try:
             vif = self.plugin.add(params)
             data = jsonutils.dumps(vif.obj_to_primitive())
+        except (exceptions.CNIPodGone, exceptions.CNIPodUidMismatch) as e:
+            LOG.warning('Pod deleted while processing ADD request')
+            error = self._error(ErrContainerUnknown, str(e))
+            return error, httplib.GONE, self.headers
         except exceptions.CNITimeout as e:
             LOG.exception('Timeout on ADD request')
             error = self._error(ErrTryAgainLater, f"{e}. Try Again Later.")
@@ -250,99 +248,6 @@ class CNIDaemonServerService(cotyledon.Service):
         self.server.stop()
 
 
-class CNIDaemonWatcherService(cotyledon.Service):
-    name = "watcher"
-
-    def __init__(self, worker_id, registry, healthy):
-        super(CNIDaemonWatcherService, self).__init__(worker_id)
-        self.pipeline = None
-        self.watcher = None
-        self.health_thread = None
-        self.registry = registry
-        self.healthy = healthy
-
-    def _get_nodename(self):
-        # NOTE(dulek): At first try to get it using environment variable,
-        #              otherwise assume hostname is the nodename.
-        try:
-            nodename = os.environ['KUBERNETES_NODE_NAME']
-        except KeyError:
-            # NOTE(dulek): By default K8s nodeName is lowercased hostname.
-            nodename = socket.gethostname().lower()
-        return nodename
-
-    def run(self):
-        self.pipeline = h_cni.CNIPipeline()
-        self.pipeline.register(h_cni.CallbackHandler(self.on_done,
-                                                     self.on_deleted))
-        self.watcher = k_watcher.Watcher(self.pipeline)
-        query_label = urllib.parse.quote_plus(f'{k_const.KURYRPORT_LABEL}='
-                                              f'{self._get_nodename()}')
-
-        self.watcher.add(f'{k_const.K8S_API_CRD_KURYRPORTS}'
-                         f'?labelSelector={query_label}')
-
-        self.is_running = True
-        self.health_thread = threading.Thread(
-            target=self._start_watcher_health_checker)
-        self.health_thread.start()
-        self.watcher.start()
-
-    def _start_watcher_health_checker(self):
-        while self.is_running:
-            if not self.watcher.is_alive():
-                LOG.debug("Reporting watcher not healthy.")
-                with self.healthy.get_lock():
-                    self.healthy.value = False
-            time.sleep(HEALTH_CHECKER_DELAY)
-
-    def on_done(self, kuryrport, vifs):
-        kp_name = utils.get_res_unique_name(kuryrport)
-        with lockutils.lock(kp_name, external=True):
-            if (kp_name not in self.registry or
-                    self.registry[kp_name]['kp']['metadata']['uid']
-                    != kuryrport['metadata']['uid']):
-                self.registry[kp_name] = {'kp': kuryrport,
-                                          'vifs': vifs,
-                                          'containerid': None,
-                                          'vif_unplugged': False,
-                                          'del_received': False}
-            else:
-                old_vifs = self.registry[kp_name]['vifs']
-                for iface in vifs:
-                    if old_vifs[iface].active != vifs[iface].active:
-                        kp_dict = self.registry[kp_name]
-                        kp_dict['vifs'] = vifs
-                        self.registry[kp_name] = kp_dict
-
-    def on_deleted(self, kp):
-        kp_name = utils.get_res_unique_name(kp)
-        try:
-            if kp_name in self.registry:
-                # NOTE(ndesh): We need to lock here to avoid race condition
-                #              with the deletion code for CNI DEL so that
-                #              we delete the registry entry exactly once
-                with lockutils.lock(kp_name, external=True):
-                    if self.registry[kp_name]['vif_unplugged']:
-                        del self.registry[kp_name]
-                    else:
-                        kp_dict = self.registry[kp_name]
-                        kp_dict['del_received'] = True
-                        self.registry[kp_name] = kp_dict
-        except KeyError:
-            # This means someone else removed it. It's odd but safe to ignore.
-            LOG.debug('KuryrPort %s entry already removed from registry while '
-                      'handling DELETED event. Ignoring.', kp_name)
-            pass
-
-    def terminate(self):
-        self.is_running = False
-        if self.health_thread:
-            self.health_thread.join()
-        if self.watcher:
-            self.watcher.stop()
-
-
 class CNIDaemonHealthServerService(cotyledon.Service):
     name = "health"
 
@@ -406,7 +311,10 @@ class CNIDaemonServiceManager(cotyledon.ServiceManager):
         registry = self.manager.dict()  # For Watcher->Server communication.
         healthy = multiprocessing.Value(c_bool, True)
         metrics = self.manager.Queue()
-        self.add(CNIDaemonWatcherService, workers=1, args=(registry, healthy,))
+        self.add(watcher_service.KuryrPortWatcherService, workers=1,
+                 args=(registry, healthy,))
+        self.add(watcher_service.PodWatcherService, workers=1,
+                 args=(registry, healthy,))
         self._server_service = self.add(CNIDaemonServerService, workers=1,
                                         args=(registry, healthy, metrics,))
         self.add(CNIDaemonHealthServerService, workers=1, args=(healthy,))

--- a/kuryr_kubernetes/cni/daemon/service.py
+++ b/kuryr_kubernetes/cni/daemon/service.py
@@ -156,9 +156,9 @@ class DaemonServer(object):
 
         try:
             self.plugin.delete(params)
-        except exceptions.CNIKuryrPortTimeout:
-            # NOTE(dulek): It's better to ignore this error - most of the time
-            #              it will happen when pod is long gone and CRI
+        except (exceptions.CNIKuryrPortTimeout, exceptions.CNIPodUidMismatch):
+            # NOTE(dulek): It's better to ignore these errors - most of the
+            #              time it will happen when pod is long gone and CRI
             #              overzealously tries to delete it from the network.
             #              We cannot really do anything without VIF annotation,
             #              so let's just tell CRI to move along.

--- a/kuryr_kubernetes/cni/daemon/watcher_service.py
+++ b/kuryr_kubernetes/cni/daemon/watcher_service.py
@@ -1,0 +1,105 @@
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import socket
+import threading
+import time
+import urllib.parse
+
+import cotyledon
+from oslo_config import cfg
+from oslo_log import log as logging
+
+from kuryr_kubernetes.cni import handlers
+from kuryr_kubernetes import constants as k_const
+from kuryr_kubernetes import watcher as k_watcher
+
+
+HEALTH_CHECKER_DELAY = 5
+LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
+
+
+class BaseCNIDaemonWatcherService(cotyledon.Service):
+    name = "watcher"
+
+    def __init__(self, worker_id, handler, path, registry, healthy):
+        super().__init__(worker_id)
+        self.pipeline = None
+        self.watcher = None
+        self.health_thread = None
+        self.handler = handler
+        self.registry = registry
+        self.healthy = healthy
+        self.path = path
+        self.is_running = False
+
+    def _get_nodename(self):
+        # NOTE(dulek): At first try to get it using environment variable,
+        #              otherwise assume hostname is the nodename.
+        try:
+            nodename = os.environ['KUBERNETES_NODE_NAME']
+        except KeyError:
+            # NOTE(dulek): By default K8s nodeName is lowercased hostname.
+            nodename = socket.gethostname().lower()
+        return nodename
+
+    def run(self):
+        self.pipeline = handlers.CNIPipeline()
+        self.pipeline.register(self.handler)
+        self.watcher = k_watcher.Watcher(self.pipeline)
+        self.watcher.add(self.path)
+
+        self.is_running = True
+
+        self.health_thread = threading.Thread(
+            target=self._start_watcher_health_checker)
+        self.health_thread.start()
+
+        self.watcher.start()
+
+    def _start_watcher_health_checker(self):
+        while self.is_running:
+            if not self.watcher.is_alive():
+                LOG.warning(f"Reporting watcher {self.__class__.__name__} is "
+                            f"not healthy because it's not running anymore.")
+                with self.healthy.get_lock():
+                    self.healthy.value = False
+            time.sleep(HEALTH_CHECKER_DELAY)
+
+    def terminate(self):
+        self.is_running = False
+        if self.health_thread:
+            self.health_thread.join()
+        if self.watcher:
+            self.watcher.stop()
+
+
+class KuryrPortWatcherService(BaseCNIDaemonWatcherService):
+    def __init__(self, worker_id, registry, healthy):
+        query_label = urllib.parse.quote_plus(f'{k_const.KURYRPORT_LABEL}='
+                                              f'{self._get_nodename()}')
+        path = f'{k_const.K8S_API_CRD_KURYRPORTS}?labelSelector={query_label}'
+        handler = handlers.CNIKuryrPortHandler(registry)
+        super().__init__(worker_id, handler, path, registry, healthy)
+
+
+class PodWatcherService(BaseCNIDaemonWatcherService):
+    def __init__(self, worker_id, registry, healthy):
+        query_label = urllib.parse.quote_plus(f'spec.nodeName='
+                                              f'{self._get_nodename()}')
+        path = f'{k_const.K8S_API_PODS}?fieldSelector={query_label}'
+        handler = handlers.CNIPodHandler(registry)
+        super().__init__(worker_id, handler, path, registry, healthy)

--- a/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
+++ b/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
@@ -31,15 +31,6 @@ LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
 RETRY_DELAY = 1000  # 1 second in milliseconds
 
-# TODO(dulek, gryf): Another corner case is (and was) when pod is deleted
-# before it's corresponding CRD was created and populated by vifs by
-# controller or even noticed by any watcher. Kubelet will try to delete such
-# vif, but we will have no data about it. This is currently worked around by
-# returning successfully in case of timing out in delete. To solve this
-# properly we need to watch for pod deletes as well, or perhaps create
-# finalizer for the pod as soon, as we know, that kuryrport CRD will be
-# created.
-
 
 class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
     def __init__(self, registry, healthy):
@@ -57,6 +48,8 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
         try:
             return self.k8s.get(
                 f'{k_const.K8S_API_NAMESPACES}/{namespace}/pods/{name}')
+        except exceptions.K8sResourceNotFound:
+            return None
         except exceptions.K8sClientException:
             uniq_name = self._get_obj_name(params)
             LOG.exception('Error when getting Pod %s', uniq_name)
@@ -72,6 +65,8 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
         if 'K8S_POD_UID' not in params.args:
             # CRI doesn't pass K8S_POD_UID, get it from the API.
             pod = self._get_pod(params)
+            if not pod:
+                raise exceptions.CNIPodGone(kp_name)
             params.args.K8S_POD_UID = pod['metadata']['uid']
 
         vifs = self._do_work(params, b_base.connect, timeout)
@@ -116,6 +111,14 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
     def delete(self, params):
         kp_name = self._get_obj_name(params)
         try:
+            with lockutils.lock(kp_name, external=True):
+                kp = self.registry[kp_name]
+                if kp == k_const.CNI_DELETED_POD_SENTINEL:
+                    LOG.warning(
+                        'Received DEL request for deleted Pod %s without a'
+                        'KuryrPort. Ignoring.', kp_name)
+                    del self.registry[kp_name]
+                    return
             reg_ci = self.registry[kp_name]['containerid']
             LOG.debug('Read containerid = %s for KuryrPort %s', reg_ci,
                       kp_name)
@@ -178,6 +181,10 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
                             e, (KeyError, exceptions.CNIPodUidMismatch)))
         def find():
             d = self.registry[kp_name]
+            if d == k_const.CNI_DELETED_POD_SENTINEL:
+                # Pod got deleted meanwhile
+                raise exceptions.CNIPodGone(kp_name)
+
             static = d['kp']['spec'].get('podStatic', None)
             uid = d['kp']['spec']['podUid']
             # FIXME(dulek): This is weirdly structured for upgrades support.

--- a/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
+++ b/kuryr_kubernetes/cni/plugins/k8s_cni_registry.py
@@ -48,31 +48,31 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
         self.k8s = clients.get_kubernetes_client()
 
     def _get_obj_name(self, params):
-        return "%(namespace)s/%(name)s" % {
-            'namespace': params.args.K8S_POD_NAMESPACE,
-            'name': params.args.K8S_POD_NAME}
+        return f'{params.args.K8S_POD_NAMESPACE}/{params.args.K8S_POD_NAME}'
+
+    def _get_pod(self, params):
+        namespace = params.args.K8S_POD_NAMESPACE
+        name = params.args.K8S_POD_NAME
+
+        try:
+            return self.k8s.get(
+                f'{k_const.K8S_API_NAMESPACES}/{namespace}/pods/{name}')
+        except exceptions.K8sClientException:
+            uniq_name = self._get_obj_name(params)
+            LOG.exception('Error when getting Pod %s', uniq_name)
+            raise
 
     def add(self, params):
         kp_name = self._get_obj_name(params)
         timeout = CONF.cni_daemon.vif_annotation_timeout
 
-        # Try to confirm if CRD in the registry is not stale cache. If it is,
-        # remove it.
-        with lockutils.lock(kp_name, external=True):
-            if kp_name in self.registry:
-                cached_kp = self.registry[kp_name]['kp']
-                try:
-                    kp = self.k8s.get(k_utils.get_res_link(cached_kp))
-                except Exception:
-                    LOG.exception('Error when getting KuryrPort %s', kp_name)
-                    raise exceptions.ResourceNotReady(kp_name)
-
-                if kp['metadata']['uid'] != cached_kp['metadata']['uid']:
-                    LOG.warning('Stale KuryrPort %s detected in cache. (API '
-                                'uid=%s, cached uid=%s). Removing it from '
-                                'cache.', kp_name, kp['metadata']['uid'],
-                                cached_kp['metadata']['uid'])
-                    del self.registry[kp_name]
+        # In order to fight race conditions when pods get recreated with the
+        # same name (think StatefulSet), we're trying to get pod UID either
+        # from the request or the API in order to use it as the ID to compare.
+        if 'K8S_POD_UID' not in params.args:
+            # CRI doesn't pass K8S_POD_UID, get it from the API.
+            pod = self._get_pod(params)
+            params.args.K8S_POD_UID = pod['metadata']['uid']
 
         vifs = self._do_work(params, b_base.connect, timeout)
 
@@ -137,7 +137,7 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
         # delay before registry is populated by watcher.
         try:
             self._do_work(params, b_base.disconnect, 5)
-        except exceptions.CNIKuryrPortTimeout:
+        except (exceptions.CNIKuryrPortTimeout, exceptions.CNIPodUidMismatch):
             # So the VIF info seems to be lost at this point, we don't even
             # know what binding driver was used to plug it. Let's at least
             # try to remove the interface we created from the netns to prevent
@@ -169,19 +169,42 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
                 LOG.debug("Reporting CNI driver not healthy.")
                 self.healthy.value = driver_healthy
 
-    def _do_work(self, params, fn, timeout):
+    def _get_vifs_from_registry(self, params, timeout):
         kp_name = self._get_obj_name(params)
 
         # In case of KeyError retry for `timeout` s, wait 1 s between tries.
         @retrying.retry(stop_max_delay=timeout * 1000, wait_fixed=RETRY_DELAY,
-                        retry_on_exception=lambda e: isinstance(e, KeyError))
+                        retry_on_exception=lambda e: isinstance(
+                            e, (KeyError, exceptions.CNIPodUidMismatch)))
         def find():
-            return self.registry[kp_name]
+            d = self.registry[kp_name]
+            static = d['kp']['spec'].get('podStatic', None)
+            uid = d['kp']['spec']['podUid']
+            # FIXME(dulek): This is weirdly structured for upgrades support.
+            #               If podStatic is not set (KuryrPort created by old
+            #               Kuryr version), then on uid mismatch we're fetching
+            #               pod from API and check if it's static here. Pods
+            #               are quite ephemeral, so will gradually get replaced
+            #               after the upgrade and in a while all should have
+            #               the field set and the performance penalty should
+            #               be resolved. Remove in the future.
+            if 'K8S_POD_UID' in params.args and uid != params.args.K8S_POD_UID:
+                if static is None:
+                    pod = self._get_pod(params)
+                    static = k_utils.is_pod_static(pod)
+
+                # Static pods have mirror pod UID in API, so it's always
+                # mismatched. We don't raise in that case. See [1] for more.
+                # [1] https://github.com/k8snetworkplumbingwg/multus-cni/
+                #     issues/773
+                if not static:
+                    raise exceptions.CNIPodUidMismatch(
+                        kp_name, params.args.K8S_POD_UID, uid)
+            return d
 
         try:
             d = find()
-            kp = d['kp']
-            vifs = d['vifs']
+            return d['kp'], d['vifs']
         except KeyError:
             data = {'metadata': {'name': params.args.K8S_POD_NAME,
                                  'namespace': params.args.K8S_POD_NAMESPACE}}
@@ -191,6 +214,9 @@ class K8sCNIRegistryPlugin(base_cni.CNIPlugin):
                                f'created for {kp_name}. Check '
                                f'kuryr-controller logs.', 'Warning')
             raise exceptions.CNIKuryrPortTimeout(kp_name)
+
+    def _do_work(self, params, fn, timeout):
+        kp, vifs = self._get_vifs_from_registry(params, timeout)
 
         for ifname, vif in vifs.items():
             is_default_gateway = (ifname == k_const.DEFAULT_IFNAME)

--- a/kuryr_kubernetes/cni/utils.py
+++ b/kuryr_kubernetes/cni/utils.py
@@ -58,6 +58,9 @@ class CNIArgs(object):
             if not k.startswith('_'):
                 setattr(self, k, v)
 
+    def __contains__(self, key):
+        return hasattr(self, key)
+
 
 class CNIParameters(object):
     def __init__(self, env, cfg=None):

--- a/kuryr_kubernetes/constants.py
+++ b/kuryr_kubernetes/constants.py
@@ -76,6 +76,7 @@ K8S_ANNOTATION_CURRENT_DRIVER = 'current_driver'
 K8S_ANNOTATION_NEUTRON_PORT = 'neutron_id'
 
 K8S_ANNOTATION_HEADLESS_SERVICE = 'service.kubernetes.io/headless'
+K8S_ANNOTATION_CONFIG_SOURCE = 'kubernetes.io/config.source'
 
 POD_FINALIZER = KURYR_FQDN + '/pod-finalizer'
 KURYRNETWORK_FINALIZER = 'kuryrnetwork.finalizers.kuryr.openstack.org'

--- a/kuryr_kubernetes/constants.py
+++ b/kuryr_kubernetes/constants.py
@@ -16,6 +16,7 @@
 KURYR_FQDN = 'kuryr.openstack.org'
 
 K8S_API_BASE = '/api/v1'
+K8S_API_PODS = K8S_API_BASE + '/pods'
 K8S_API_NAMESPACES = K8S_API_BASE + '/namespaces'
 K8S_API_CRD_VERSION = 'openstack.org/v1'
 K8S_API_CRD = '/apis/' + K8S_API_CRD_VERSION
@@ -91,6 +92,7 @@ K8S_OS_VIF_NOOP_PLUGIN = "noop"
 
 CNI_EXCEPTION_CODE = 100
 CNI_TIMEOUT_CODE = 200
+CNI_DELETED_POD_SENTINEL = None
 
 KURYR_PORT_NAME = 'kuryr-pool-port'
 KURYR_VIF_TYPE_SRIOV = 'sriov'

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -207,7 +207,8 @@ class VIFHandler(k8s_base.ResourceEventHandler):
             },
             'spec': {
                 'podUid': pod['metadata']['uid'],
-                'podNodeName': pod['spec']['nodeName']
+                'podNodeName': pod['spec']['nodeName'],
+                'podStatic': utils.is_pod_static(pod)
             },
             'status': {
                 'vifs': vifs

--- a/kuryr_kubernetes/exceptions.py
+++ b/kuryr_kubernetes/exceptions.py
@@ -170,13 +170,20 @@ class CNIBindingFailure(Exception):
         super(CNIBindingFailure, self).__init__(message)
 
 
-class CNIPodUidMismatch(CNITimeout):
+class CNIPodUidMismatch(Exception):
     """Excepton raised on a mismatch of CNI request's pod UID and KuryrPort"""
     def __init__(self, name, expected, observed):
         super().__init__(
             f'uid {observed} of the pod {name} does not match the uid '
             f'{expected} requested by the CNI. Dropping CNI request to prevent'
             f' race conditions.')
+
+
+class CNIPodGone(Exception):
+    """Excepton raised when Pod got deleted while processing a CNI request"""
+    def __init__(self, name):
+        super().__init__(
+            f'Pod {name} got deleted while processing the CNI ADD request.')
 
 
 class UnreachableOctavia(Exception):

--- a/kuryr_kubernetes/exceptions.py
+++ b/kuryr_kubernetes/exceptions.py
@@ -170,6 +170,15 @@ class CNIBindingFailure(Exception):
         super(CNIBindingFailure, self).__init__(message)
 
 
+class CNIPodUidMismatch(CNITimeout):
+    """Excepton raised on a mismatch of CNI request's pod UID and KuryrPort"""
+    def __init__(self, name, expected, observed):
+        super().__init__(
+            f'uid {observed} of the pod {name} does not match the uid '
+            f'{expected} requested by the CNI. Dropping CNI request to prevent'
+            f' race conditions.')
+
+
 class UnreachableOctavia(Exception):
     """Exception indicates Octavia API failure and can not be reached
 

--- a/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
+++ b/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
@@ -197,8 +197,9 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                                      is_default_gateway=False,
                                      container_id='cont_id')
 
+    @mock.patch('oslo_concurrency.lockutils.lock')
     @mock.patch('kuryr_kubernetes.cni.binding.base.disconnect')
-    def test_del_wrong_container_id(self, m_disconnect):
+    def test_del_wrong_container_id(self, m_disconnect, m_lock):
         registry = {'default/foo': {'kp': self.kp, 'vifs': self.vifs,
                                     'containerid': 'different'}}
         healthy = mock.Mock()
@@ -206,6 +207,7 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
         self.plugin.delete(self.params)
 
         m_disconnect.assert_not_called()
+        m_lock.assert_called_with('default/foo', external=True)
 
     @mock.patch('oslo_concurrency.lockutils.lock')
     @mock.patch('time.sleep', mock.Mock())

--- a/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
+++ b/kuryr_kubernetes/tests/unit/cni/plugins/test_k8s_cni_registry.py
@@ -17,6 +17,7 @@ from unittest import mock
 from oslo_config import cfg
 
 from kuryr_kubernetes.cni.plugins import k8s_cni_registry
+from kuryr_kubernetes.cni import utils
 from kuryr_kubernetes import exceptions
 from kuryr_kubernetes.tests import base
 from kuryr_kubernetes.tests import fake
@@ -33,7 +34,7 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                    'kind': 'KuryrPort',
                    'metadata': {'name': 'foo', 'uid': 'bar',
                                 'namespace': 'default'},
-                   'spec': {'podUid': 'bar'}}
+                   'spec': {'podUid': 'bar', 'podStatic': False}}
         self.vifs = fake._fake_vifs()
         registry = {'default/foo': {'kp': self.kp, 'vifs': self.vifs,
                                     'containerid': None,
@@ -41,10 +42,11 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                                     'del_received': False}}
         healthy = mock.Mock()
         self.plugin = k8s_cni_registry.K8sCNIRegistryPlugin(registry, healthy)
-        self.params = mock.Mock(args=mock.Mock(K8S_POD_NAME='foo',
-                                               K8S_POD_NAMESPACE='default'),
-                                CNI_IFNAME=self.default_iface, CNI_NETNS=123,
-                                CNI_CONTAINERID='cont_id')
+        self.params = mock.Mock(
+            args=utils.CNIArgs('K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default;'
+                               'K8S_POD_UID=bar'),
+            CNI_IFNAME=self.default_iface, CNI_NETNS=123,
+            CNI_CONTAINERID='cont_id')
 
     @mock.patch('oslo_concurrency.lockutils.lock')
     @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
@@ -62,6 +64,101 @@ class TestK8sCNIRegistryPlugin(base.TestCase):
                                   123, report_health=mock.ANY,
                                   is_default_gateway=False,
                                   container_id='cont_id')
+        self.assertEqual('cont_id',
+                         self.plugin.registry['default/foo']['containerid'])
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
+    def test_add_no_uid(self, m_connect, m_lock):
+        self.k8s_mock.get.return_value = self.kp
+
+        self.params.args = utils.CNIArgs(
+            'K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default')
+        self.plugin.add(self.params)
+
+        m_lock.assert_called_with('default/foo', external=True)
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.default_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=True,
+                                  container_id='cont_id')
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.additional_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=False,
+                                  container_id='cont_id')
+        self.k8s_mock.get.assert_any_call(
+            '/api/v1/namespaces/default/pods/foo')
+        self.assertEqual('cont_id',
+                         self.plugin.registry['default/foo']['containerid'])
+
+    @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
+    def test_add_wrong_uid(self, m_connect):
+        cfg.CONF.set_override('vif_annotation_timeout', 0, group='cni_daemon')
+        self.addCleanup(cfg.CONF.set_override, 'vif_annotation_timeout', 120,
+                        group='cni_daemon')
+        self.k8s_mock.get.return_value = self.kp
+
+        self.params.args = utils.CNIArgs(
+            'K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default;K8S_POD_UID=blob')
+        self.assertRaises(exceptions.CNIPodUidMismatch, self.plugin.add,
+                          self.params)
+
+        m_connect.assert_not_called()
+        self.k8s_mock.get.assert_not_called()
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
+    def test_add_wrong_uid_static(self, m_connect, m_lock):
+        cfg.CONF.set_override('vif_annotation_timeout', 0, group='cni_daemon')
+        self.addCleanup(cfg.CONF.set_override, 'vif_annotation_timeout', 120,
+                        group='cni_daemon')
+        self.k8s_mock.get.return_value = self.kp
+
+        self.params.args = utils.CNIArgs(
+            'K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default;K8S_POD_UID=blob')
+        self.kp['spec']['podStatic'] = True
+        self.plugin.add(self.params)
+
+        m_lock.assert_called_with('default/foo', external=True)
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.default_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=True,
+                                  container_id='cont_id')
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.additional_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=False,
+                                  container_id='cont_id')
+        self.k8s_mock.get.assert_any_call(
+            '/api/v1/namespaces/default/pods/foo')
+        self.assertEqual('cont_id',
+                         self.plugin.registry['default/foo']['containerid'])
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    @mock.patch('kuryr_kubernetes.cni.binding.base.connect')
+    def test_add_wrong_uid_none_static(self, m_connect, m_lock):
+        cfg.CONF.set_override('vif_annotation_timeout', 0, group='cni_daemon')
+        self.addCleanup(cfg.CONF.set_override, 'vif_annotation_timeout', 120,
+                        group='cni_daemon')
+        self.k8s_mock.get.side_effect = [
+            {'metadata': {
+                'annotations': {'kubernetes.io/config.source': 'file'}}},
+            self.kp]
+
+        self.params.args = utils.CNIArgs(
+            'K8S_POD_NAME=foo;K8S_POD_NAMESPACE=default;K8S_POD_UID=blob')
+        del self.kp['spec']['podStatic']
+        self.plugin.add(self.params)
+
+        m_lock.assert_called_with('default/foo', external=True)
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.default_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=True,
+                                  container_id='cont_id')
+        m_connect.assert_any_call(mock.ANY, mock.ANY, self.additional_iface,
+                                  123, report_health=mock.ANY,
+                                  is_default_gateway=False,
+                                  container_id='cont_id')
+        self.k8s_mock.get.assert_any_call(
+            '/api/v1/namespaces/default/pods/foo')
         self.assertEqual('cont_id',
                          self.plugin.registry['default/foo']['containerid'])
 

--- a/kuryr_kubernetes/tests/unit/cni/test_handlers.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_handlers.py
@@ -1,0 +1,68 @@
+# Copyright 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from kuryr_kubernetes.cni import handlers
+from kuryr_kubernetes.tests import base
+
+
+class TestCNIDaemonHandlers(base.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.registry = {}
+        self.pod = {'metadata': {'namespace': 'testing',
+                                 'name': 'default'},
+                    'vif_unplugged': False,
+                    'del_receieved': False}
+        self.healthy = mock.Mock()
+        self.port_handler = handlers.CNIKuryrPortHandler(self.registry)
+        self.pod_handler = handlers.CNIPodHandler(self.registry)
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_kp_on_deleted(self, m_lock):
+        pod = self.pod
+        pod['vif_unplugged'] = True
+        pod_name = 'testing/default'
+        self.registry[pod_name] = pod
+        self.port_handler.on_deleted(pod)
+        self.assertNotIn(pod_name, self.registry)
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_kp_on_deleted_false(self, m_lock):
+        pod = self.pod
+        pod_name = 'testing/default'
+        self.registry[pod_name] = pod
+        self.port_handler.on_deleted(pod)
+        self.assertIn(pod_name, self.registry)
+        self.assertIs(True, pod['del_received'])
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_pod_on_finalize(self, m_lock):
+        pod = self.pod
+        pod_name = 'testing/default'
+        self.pod_handler.on_finalize(pod)
+        self.assertIn(pod_name, self.registry)
+        self.assertIsNone(self.registry[pod_name])
+        m_lock.assert_called_once_with(pod_name, external=True)
+
+    @mock.patch('oslo_concurrency.lockutils.lock')
+    def test_pod_on_finalize_exists(self, m_lock):
+        pod = self.pod
+        pod_name = 'testing/default'
+        self.registry[pod_name] = pod
+        self.pod_handler.on_finalize(pod)
+        self.assertIn(pod_name, self.registry)
+        self.assertIsNotNone(self.registry[pod_name])
+        m_lock.assert_called_once_with(pod_name, external=True)

--- a/kuryr_kubernetes/tests/unit/cni/test_service.py
+++ b/kuryr_kubernetes/tests/unit/cni/test_service.py
@@ -107,34 +107,3 @@ class TestDaemonServer(base.TestCase):
 
         m_delete.assert_called_once_with(mock.ANY)
         self.assertEqual(500, resp.status_code)
-
-
-class TestCNIDaemonWatcherService(base.TestCase):
-    def setUp(self):
-        super(TestCNIDaemonWatcherService, self).setUp()
-        self.registry = {}
-        self.pod = {'metadata': {'namespace': 'testing',
-                                 'name': 'default'},
-                    'vif_unplugged': False,
-                    'del_receieved': False}
-        self.healthy = mock.Mock()
-        self.watcher = service.CNIDaemonWatcherService(
-            0, self.registry, self.healthy)
-
-    @mock.patch('oslo_concurrency.lockutils.lock')
-    def test_on_deleted(self, m_lock):
-        pod = self.pod
-        pod['vif_unplugged'] = True
-        pod_name = 'testing/default'
-        self.registry[pod_name] = pod
-        self.watcher.on_deleted(pod)
-        self.assertNotIn(pod_name, self.registry)
-
-    @mock.patch('oslo_concurrency.lockutils.lock')
-    def test_on_deleted_false(self, m_lock):
-        pod = self.pod
-        pod_name = 'testing/default'
-        self.registry[pod_name] = pod
-        self.watcher.on_deleted(pod)
-        self.assertIn(pod_name, self.registry)
-        self.assertIs(True, pod['del_received'])

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -649,6 +649,16 @@ def is_host_network(pod):
     return pod['spec'].get('hostNetwork', False)
 
 
+def is_pod_static(pod):
+    """Checks if Pod is static by comparing annotations."""
+    try:
+        annotations = pod['metadata']['annotations']
+        config_source = annotations[constants.K8S_ANNOTATION_CONFIG_SOURCE]
+        return config_source != 'api'
+    except KeyError:
+        return False
+
+
 def get_referenced_object(obj, kind):
     """Get referenced object.
 


### PR DESCRIPTION
Recent versions of cri-o and containerd are passing K8S_POD_UID as a CNI
argument, alongside with K8S_POD_NAMESPACE and K8S_POD_NAME. As both
latter variables cannot be used to safely identify a pod in the API
(StatefulSet recreates pods with the same name), we were prone to race
conditions in the CNI code that we could only workaround. The end effect
was mostly IP conflict.

Now that the UID argument is passed, we're able to compare the UID from
the request with the one in the API to make sure we're wiring the
correct pod. This commit implements that by making sure to move the
check to the code actually waiting for the pod to appear in the
registry. In case of K8S_POD_UID missing from the CNI request, API call
to retrieve Pod is used as a fallback.

We also know that this check doesn't work for static pods, so CRD and
controller needed to be updated to include information if the pod is
static on the KuryrPort spec, so that we can skip the check for the
static pods without the need to fetch Pod from the API.

It can happen that we get the CNI request, but pod gets deleted before
kuryr-controller was able to create KuryrPort for it. If kuryr-daemon
only watches for KuryrPort events it will not be able to notice that
and will wait until the timeout, which in effect doesn't play well with
some K8s tests.

This commit adds a separate Service that will watch on Pod events and if
Pod gets deleted we'll make sure to put a sentinel value (None) into the
registry so that the thread waiting for the KuryrPort to appear there
will know that it has to stop and raise an error.