### PR TITLE
OCPBUGS-11993: Fix VIF revert on KuryrPort status update error

### DIFF
--- a/kuryr_kubernetes/controller/handlers/kuryrport.py
+++ b/kuryr_kubernetes/controller/handlers/kuryrport.py
@@ -330,9 +330,7 @@ class KuryrPortHandler(k8s_base.ResourceEventHandler):
             LOG.exception("Kubernetes Client Exception creating "
                           "KuryrPort CRD: %s", ex)
             for ifname, data in vifs.items():
-                self._drv_vif_pool.release_vif(pod, data['vif'],
-                                               project_id,
-                                               security_groups)
+                self._drv_vif_pool.release_vif(pod, data['vif'], project_id)
             self.k8s.add_event(pod, 'ExceptionOnKPUpdate', f'There was k8s '
                                f'client exception on updating corresponding '
                                f'KuryrPort CRD: {ex}', 'Warning')

--- a/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrport.py
+++ b/kuryr_kubernetes/tests/unit/controller/handlers/test_kuryrport.py
@@ -630,8 +630,7 @@ class TestKuryrPortHandler(test_base.TestCase):
                                             {'default': True,
                                              'vif': self._vif1}})
         release_vif.assert_called_once_with(self._pod, self._vif1,
-                                            self._project_id,
-                                            self._security_groups)
+                                            self._project_id)
 
     @mock.patch('kuryr_kubernetes.clients.get_kubernetes_client')
     @mock.patch('kuryr_kubernetes.controller.drivers.base.MultiVIFDriver.'


### PR DESCRIPTION
There's argument number mismatch on release_vif() call while reverting port association. This commit fixes that.