### PR TITLE
[4.14] Add changelog section to the specfile

### DIFF
--- a/openshift-kuryr-kubernetes-rhel8.spec
+++ b/openshift-kuryr-kubernetes-rhel8.spec
@@ -202,3 +202,5 @@ exit 0
 %dir %attr(0755, root, root) %{_libexecdir}/%{project}
 %{_libexecdir}/%{project}/cni_ds_init
 %config(noreplace) %attr(0640, root, %{project}) %{_sysconfdir}/%{project}-cni/10-kuryr.conflist
+
+%changelog


### PR DESCRIPTION
ART relies upon the changelog to determine if the RPM has changed. This contributes to deciding whether kuryr images should be rebuilt. A missing changelog section is causing ART to continuously rebuild those images, even though they did not change since last successful build.